### PR TITLE
Corrected database setup and teardown of bare pytest classes.

### DIFF
--- a/tests/test_classbasedtests.py
+++ b/tests/test_classbasedtests.py
@@ -1,0 +1,12 @@
+from .app.models import Item
+
+
+class TestBarePytestClass:
+    def setup_method(self, method):
+        Item.objects.create(name='unique_name')
+
+    def test_fresh_database(self):
+        assert Item.objects.count() == 1
+
+    def test_fresh_database_again(self):
+        self.test_fresh_database()


### PR DESCRIPTION
Flushes the database on teardown, and deals with a few other necessities, when a test-case is just a bare pytest class (i.e. not a subclass of Django's TestCase).
