### PR TITLE
Better handling of south migrations for newer versions of south.

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -78,10 +78,11 @@ def pytest_addoption(parser):
 
 def _handle_south_management_command():
     try:
+        # if `south` >= 0.7.1 we can use the test helper
         from south.management.commands import patch_for_test_db_setup
     except ImportError:
+        # if `south` < 0.7.1 make sure it's migrations are disabled
         management.get_commands()
-        # make sure `south` migrations are disabled
         management._commands['syncdb'] = 'django.core'
     else:
         patch_for_test_db_setup()


### PR DESCRIPTION
Hi,

We have tests that require `south` migrations to be run. This runner currently disables them and our tests fail.

In `south` >= 0.7.1 there is a helper in `south.management.commands` called `patch_for_test_db_setup` that inspects the Django configuration for a setting and either disables migrations or handles them.

This patch changes the `_disable_south_management_command()` method so that it uses this method.
