### PR TITLE
Rely on django.conf.settings.configured whenever possible

### DIFF
--- a/pytest_django/lazy_django.py
+++ b/pytest_django/lazy_django.py
@@ -15,7 +15,7 @@ def skip_if_no_django():
 
 def django_settings_is_configured():
     try:
-        import django.conf
+        from django.conf import settings
     except ImportError:
         return False
-    return django.conf.settings.configured or bool(os.environ.get('DJANGO_SETTINGS_MODULE'))
+    return settings.configured or bool(os.environ.get('DJANGO_SETTINGS_MODULE'))

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -64,17 +64,17 @@ def pytest_configure(config):
           config.getini(SETTINGS_MODULE_ENV) or
           os.environ.get(SETTINGS_MODULE_ENV))
     try:
-        import django.conf
+        from django.conf import settings
     except ImportError:
         raise pytest.UsageError('Django could not be imported')
 
     if ds:
         os.environ[SETTINGS_MODULE_ENV] = config.option.ds = ds
         try:
-            django.conf.settings.DATABASES
+            settings.DATABASES
         except ImportError, e:
             raise pytest.UsageError(*e.args)  # Lazy settings import failed
-    elif django.conf.settings.configured:
+    elif settings.configured:
         config.option.ds = 'auto'
     else:
         os.environ.pop(SETTINGS_MODULE_ENV, None)


### PR DESCRIPTION
This is in reference to #24
