### PR TITLE
Dont adjust the value of DEBUG_PROPAGATE_EXEPTIONS

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -109,13 +109,10 @@ def _django_runner(request):
         we need to follow this model.
     """
     if request.config.option.ds:
-
-        import django.conf
         from django.test.simple import DjangoTestSuiteRunner
 
         runner = DjangoTestSuiteRunner(interactive=False)
         runner.setup_test_environment()
-        django.conf.settings.DEBUG_PROPAGATE_EXCEPTIONS = True
         request.addfinalizer(runner.teardown_test_environment)
         return runner
 


### PR DESCRIPTION
The plugin shouldn't make assumptions like this about an environment. This explicitly causes many tests to fail (that are integration tests) in the sentry client bindings (which hooks into Django exception signals), and is pretty painful to fix at a global level.

Unless there's a really good reason this is being forced, we should leave it up to the enduser to decide if they need it enabled or not.
