### PR TITLE
fix multiline strings to use dedent

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import py
 import shutil
 import copy
 
+from textwrap import dedent
+
 
 pytest_plugins = 'pytester'
 
@@ -26,22 +28,22 @@ def django_testdir(testdir, monkeypatch):
     db_settings = copy.deepcopy(settings.DATABASES)
     db_settings['default']['NAME'] = DB_NAME
 
-    test_settings = '''
-# Pypy compatibility
-try:
-    from psycopg2ct import compat
-except ImportError:
-    pass
-else:
-    compat.register()
+    test_settings = dedent("""
+        # Pypy compatibility
+        try:
+            from psycopg2ct import compat
+        except ImportError:
+            pass
+        else:
+            compat.register()
 
-DATABASES = %(db_settings)s
+        DATABASES = %(db_settings)s
 
-INSTALLED_APPS = [
-    'tpkg.app',
-]
-SECRET_KEY = 'foobar'
-''' % {'db_settings': repr(db_settings)}
+        INSTALLED_APPS = [
+            'tpkg.app',
+        ]
+        SECRET_KEY = 'foobar'
+    """ % {'db_settings': repr(db_settings)})
 
     tpkg_path = testdir.mkpydir('tpkg')
     app_source = TESTS_DIR.dirpath('app')

--- a/tests/test_db_setup.py
+++ b/tests/test_db_setup.py
@@ -1,4 +1,5 @@
 import pytest
+from textwrap import dedent
 
 from django.conf import settings
 
@@ -16,15 +17,15 @@ def test_db_reuse(django_testdir):
     if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.sqlite3':
         pytest.skip('Do not test db reuse since database does not support it')
 
-    create_test_module(django_testdir, '''
-import pytest
+    create_test_module(django_testdir, dedent("""
+        import pytest
 
-from .app.models import Item
+        from .app.models import Item
 
-@pytest.mark.django_db
-def test_db_can_be_accessed():
-    assert Item.objects.count() == 0
-''')
+        @pytest.mark.django_db
+        def test_db_can_be_accessed():
+            assert Item.objects.count() == 0
+    """))
 
     # Use --create-db on the first run to make sure we are not just re-using a
     # database from another test run

--- a/tests/test_django_configurations.py
+++ b/tests/test_django_configurations.py
@@ -8,7 +8,7 @@ import pytest
 pytestmark = pytest.mark.skipif("sys.version_info < (2,6)")
 
 
-BARE_SETTINGS = '''
+BARE_SETTINGS = """
 from configurations import Settings
 
 class MySettings(Settings):
@@ -21,7 +21,7 @@ class MySettings(Settings):
     }
 
     SECRET_KEY = 'foobar'
-'''
+"""
 
 
 def test_dc_env(testdir, monkeypatch):

--- a/tests/test_django_settings_module.py
+++ b/tests/test_django_settings_module.py
@@ -3,7 +3,7 @@
 If these tests fail you probably forgot to run "python setup.py develop".
 """
 
-BARE_SETTINGS = '''
+BARE_SETTINGS = """
 # At least one database must be configured
 DATABASES = {
     'default': {
@@ -12,7 +12,7 @@ DATABASES = {
     },
 }
 SECRET_KEY = 'foobar'
-'''
+"""
 
 
 def test_ds_env(testdir, monkeypatch):

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -1,4 +1,5 @@
 import pytest
+from textwrap import dedent
 
 from django.test import TestCase
 
@@ -75,22 +76,22 @@ def test_sole_test(django_testdir):
     are collected, without the django_db marker.
     """
 
-    create_test_module(django_testdir, '''
-from django.test import TestCase
-from django.conf import settings
+    create_test_module(django_testdir, dedent("""
+        from django.test import TestCase
+        from django.conf import settings
 
-from .app.models import Item
+        from .app.models import Item
 
-class TestFoo(TestCase):
-    def test_foo(self):
-        # Make sure we are actually using the test database
-        db_name = settings.DATABASES['default']['NAME']
-        assert db_name.startswith('test_') or db_name == ':memory:'
+        class TestFoo(TestCase):
+            def test_foo(self):
+                # Make sure we are actually using the test database
+                db_name = settings.DATABASES['default']['NAME']
+                assert db_name.startswith('test_') or db_name == ':memory:'
 
-        # Make sure it is usable
-        assert Item.objects.count() == 0
+                # Make sure it is usable
+                assert Item.objects.count() == 0
 
-''')
+    """))
 
     result = django_testdir.runpytest('-v')
     result.stdout.fnmatch_lines([


### PR DESCRIPTION
Use `textwrap.dedent` for multiline strings: allows for nicely indented strings, but still remove the indentations before saving them to files.

Thanks to @rafales for the tip (cf https://github.com/pelme/pytest_django/pull/43#issuecomment-20570728)
