### PR TITLE
Database keeps changes through one class

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -60,7 +60,6 @@ def _django_db_setup(request, _django_runner, _django_cursor_wrapper):
 ################ User visible fixtures ################
 
 
-@pytest.fixture(scope='function')
 def db(request, _django_db_setup, _django_cursor_wrapper):
     """Require a django test database
 
@@ -86,8 +85,11 @@ def db(request, _django_db_setup, _django_cursor_wrapper):
         request.addfinalizer(case._post_teardown)
         request.addfinalizer(_django_cursor_wrapper.disable)
 
+db = pytest.fixture(scope='function')(db)
 
-@pytest.fixture(scope='function')
+class_db=pytest.fixture(scope='class')(db)
+
+
 def transactional_db(request, _django_db_setup, _django_cursor_wrapper):
     """Require a django test database with transaction support
 
@@ -117,6 +119,10 @@ def transactional_db(request, _django_db_setup, _django_cursor_wrapper):
 
         request.addfinalizer(_django_cursor_wrapper.disable)
         request.addfinalizer(flushdb)
+
+transactional_db = pytest.fixture(scope='function')(transactional_db)
+
+transactional_class_db=pytest.fixture(scope='class')(transactional_db)
 
 
 @pytest.fixture()

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -160,10 +160,11 @@ def _django_db_marker(request):
     marker = request.keywords.get('django_db', None)
     if marker:
         validate_django_db(marker)
+        cls_db = 'class_db' if marker.class_db else 'db'
         if marker.transaction:
-            request.getfuncargvalue('transactional_db')
+            request.getfuncargvalue('transactional_%s'%cls_db)
         else:
-            request.getfuncargvalue('db')
+            request.getfuncargvalue(cls_db)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Changes scope of fixture 'db' dynamically, depending on kwargs for pytest.mark.django_db.
Allows one class to keep all changes in databse and allows for incremental testing of database.

!!!! BUG !!!!

    @pytest.mark.django_db(class_db=True)
    class TestDB:
        # Tests now with classDB, but without transaction

        @pytest.mark.django_db(transaction=True)
        def test_smthg(self):
            # Tests with classDB and (newly activated) transactions:
       ##### mayjor breackdown!!!!!

    @pytest.mark.django_db(True, True)
    class TestBlah:
    ### no problem

Since I don't use transactions, I don't think I will fix this anytime soon. Furthermore it's a rather rare usecase I believe.