### PR TITLE
Fix ordering of finalizers in db fixture

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -83,8 +83,8 @@ def db(request, _django_db_setup, _django_cursor_wrapper):
         _django_cursor_wrapper.enable()
         case = TestCase(methodName='__init__')
         case._pre_setup()
-        request.addfinalizer(case._post_teardown)
         request.addfinalizer(_django_cursor_wrapper.disable)
+        request.addfinalizer(case._post_teardown)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
See https://bitbucket.org/hpk42/pytest/src/17a246750c75f5eda01d065b9c72ab9fb0f1b544/_pytest/python.py?at=default#cl-1756

pytest's addfinalizer method appends finalizers to a list, and pops them off the end to call in finish(). These two lines must be switched to prevent _post_teardown accessing the blocking CursorWrapper.

It's a bit ugly in this case, but you might want to use yield_fixtures to make the ordering more explicit:

``` python
@pytest.yield_fixture(scope="function")
def django_db(_django_cursor_wrapper):
    if ('transactional_db' not in request.funcargnames and
            'live_server' not in request.funcargnames and
            not is_django_unittest(request.node)):

        from django.test import TestCase

        with _django_cursor_wrapper:
            case = TestCase(methodName='__init__')
            case._pre_setup()
            yield
            case._post_teardown()

    yield
```

It looks pretty, except for that yield at the end, which is necessary when that if case is False.
