### PR TITLE
 multidb: let one connection be reused, and other not

### DIFF
--- a/pytest_django/db_reuse.py
+++ b/pytest_django/db_reuse.py
@@ -93,13 +93,16 @@ def create_test_db_with_reuse(self, verbosity=1, autoclobber=False):
     # See https://code.djangoproject.com/ticket/17760
     if hasattr(self.connection.features, 'confirm'):
         self.connection.features.confirm()
+        
+    self.connection.settings_dict['TEST_REUSE']=True #to check if destroy or not
 
     return test_database_name
 
 
-def monkey_patch_creation_for_db_reuse():
+def monkey_patch_creation_for_db_reuse(reuse_db,create_db):
     from django.db import connections
 
     for connection in connections.all():
-        if test_database_exists_from_previous_run(connection):
-            _monkeypatch(connection.creation, 'create_test_db', create_test_db_with_reuse)
+        if reuse_db and not create_db or connection.settings_dict.get('TEST_REUSE',False):
+            if test_database_exists_from_previous_run(connection):
+                _monkeypatch(connection.creation, 'create_test_db', create_test_db_with_reuse)


### PR DESCRIPTION
set per settings.py 

instead (besides) of set --reuse_db in cmdline, I can set TEST_REUSE in db setting, which let me reuse one db (postgres in this case) , which is big and expensive to create/copy, and create other (small sqlite). 
