### PR TITLE
Support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,12 @@ env:
   - TESTENV=python2.7-master-mysql_myisam
   - TESTENV=python2.7-master-sqlite
   - TESTENV=python3.2-master-sqlite
-  - TESTENV=python3.3-1.5-sqlite
-  - TESTENV=python3.3-1.6-sqlite
-  - TESTENV=python3.3-1.7-sqlite
-  - TESTENV=python3.3-master-postgres
   - TESTENV=python3.3-master-sqlite
+  - TESTENV=python3.4-1.5-sqlite
+  - TESTENV=python3.4-1.6-sqlite
+  - TESTENV=python3.4-1.7-sqlite
+  - TESTENV=python3.4-master-postgres
+  - TESTENV=python3.4-master-sqlite
 install:
   - pip install tox
 script: tox -e $TESTENV

--- a/generate_configurations.py
+++ b/generate_configurations.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 TestEnv = namedtuple('TestEnv', ['python_version', 'django_version', 'settings'])
 
 
-PYTHON_VERSIONS = ['python2.6', 'python2.7', 'python3.2', 'python3.3', 'pypy']
+PYTHON_VERSIONS = ['python2.6', 'python2.7', 'python3.2', 'python3.3', 'python3.4', 'pypy']
 DJANGO_VERSIONS = ['1.3', '1.4', '1.5', '1.6', '1.7', 'master']
 SETTINGS = ['sqlite', 'mysql_myisam', 'mysql_innodb', 'postgres']
 DJANGO_REQUIREMENTS = {

--- a/tox.ini
+++ b/tox.ini
@@ -1008,3 +1008,131 @@ setenv =
      DJANGO_SETTINGS_MODULE = tests.settings_sqlite
      PYTHONPATH = {toxinidir}
      UID = 61
+
+
+[testenv:python3.4-1.5-postgres]
+commands =
+    sh -c "dropdb pytest_django_62; createdb pytest_django_62 || exit 0"
+    py.test {posargs}
+basepython = python3.4
+deps =
+    pytest==2.5.2
+    pytest-xdist==1.10
+    Django==1.5.5
+    django-configurations==0.8
+    psycopg2==2.5.2
+setenv =
+     DJANGO_SETTINGS_MODULE = tests.settings_postgres
+     PYTHONPATH = {toxinidir}
+     UID = 62
+
+
+[testenv:python3.4-1.5-sqlite]
+commands =
+    py.test {posargs}
+basepython = python3.4
+deps =
+    pytest==2.5.2
+    pytest-xdist==1.10
+    Django==1.5.5
+    django-configurations==0.8
+setenv =
+     DJANGO_SETTINGS_MODULE = tests.settings_sqlite
+     PYTHONPATH = {toxinidir}
+     UID = 63
+
+
+[testenv:python3.4-1.6-postgres]
+commands =
+    sh -c "dropdb pytest_django_64; createdb pytest_django_64 || exit 0"
+    py.test {posargs}
+basepython = python3.4
+deps =
+    pytest==2.5.2
+    pytest-xdist==1.10
+    Django==1.6.2
+    django-configurations==0.8
+    psycopg2==2.5.2
+setenv =
+     DJANGO_SETTINGS_MODULE = tests.settings_postgres
+     PYTHONPATH = {toxinidir}
+     UID = 64
+
+
+[testenv:python3.4-1.6-sqlite]
+commands =
+    py.test {posargs}
+basepython = python3.4
+deps =
+    pytest==2.5.2
+    pytest-xdist==1.10
+    Django==1.6.2
+    django-configurations==0.8
+setenv =
+     DJANGO_SETTINGS_MODULE = tests.settings_sqlite
+     PYTHONPATH = {toxinidir}
+     UID = 65
+
+
+[testenv:python3.4-1.7-postgres]
+commands =
+    sh -c "dropdb pytest_django_66; createdb pytest_django_66 || exit 0"
+    py.test {posargs}
+basepython = python3.4
+deps =
+    pytest==2.5.2
+    pytest-xdist==1.10
+    https://www.djangoproject.com/download/1.7b1/tarball/
+    django-configurations==0.8
+    psycopg2==2.5.2
+setenv =
+     DJANGO_SETTINGS_MODULE = tests.settings_postgres
+     PYTHONPATH = {toxinidir}
+     UID = 66
+
+
+[testenv:python3.4-1.7-sqlite]
+commands =
+    py.test {posargs}
+basepython = python3.4
+deps =
+    pytest==2.5.2
+    pytest-xdist==1.10
+    https://www.djangoproject.com/download/1.7b1/tarball/
+    django-configurations==0.8
+setenv =
+     DJANGO_SETTINGS_MODULE = tests.settings_sqlite
+     PYTHONPATH = {toxinidir}
+     UID = 67
+
+
+[testenv:python3.4-master-postgres]
+commands =
+    sh -c "dropdb pytest_django_68; createdb pytest_django_68 || exit 0"
+    py.test {posargs}
+basepython = python3.4
+deps =
+    pytest==2.5.2
+    pytest-xdist==1.10
+    https://github.com/django/django/archive/master.zip
+    django-configurations==0.8
+    psycopg2==2.5.2
+setenv =
+     DJANGO_SETTINGS_MODULE = tests.settings_postgres
+     PYTHONPATH = {toxinidir}
+     UID = 68
+
+
+[testenv:python3.4-master-sqlite]
+commands =
+    py.test {posargs}
+basepython = python3.4
+deps =
+    pytest==2.5.2
+    pytest-xdist==1.10
+    https://github.com/django/django/archive/master.zip
+    django-configurations==0.8
+setenv =
+     DJANGO_SETTINGS_MODULE = tests.settings_sqlite
+     PYTHONPATH = {toxinidir}
+     UID = 69


### PR DESCRIPTION
This is currently blocked by Travis. See #81. The tests pass locally in my machine, so this can be merged as soon as Travis adds 3.4.
