### PR TITLE
Makefile: fix `make docs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 testenv: bin/py.test
 
 
-bin/python:
+bin/python bin/pip:
 	virtualenv .
 
 bin/py.test: bin/python
@@ -13,7 +13,7 @@ test: bin/py.test
 	bin/pip install -Ur requirements.txt
 	bin/py.test
 
-bin/sphinx-build:
+bin/sphinx-build: bin/pip
 	bin/pip install sphinx
 
 docs: bin/sphinx-build


### PR DESCRIPTION
Add bin/pip as prerequisite for sphinx-build and as target itself,
provided by installing a virtualenv.
