### PR TITLE
test_sole_test: fix fnmatch_lines for pytest-2.6.0-dev

### DIFF
--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -92,7 +92,7 @@ def test_sole_test(django_testdir):
 
     result = django_testdir.runpytest('-v')
     result.stdout.fnmatch_lines([
-        "*TestFoo.test_foo PASSED*",
+        "*TestFoo*test_foo PASSED*",
     ])
     assert result.ret == 0
 


### PR DESCRIPTION
With pytest 2.6 the output format for `-v` changes:

```
from: tpkg/test_the_test.py:8: TestFoo.test_foo PASSED
to:   tpkg/test_the_test.py@8::TestFoo::test_foo PASSED
```
