### PR TITLE
Add a new fixture: admin_user

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -131,6 +131,25 @@ Example
 As an extra bonus this will automatically mark the database using the
 ``django_db`` mark.
 
+``admin_user`` - a admin user (superuser)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An instance of a superuser, with username "admin" and password "password" (in
+case there is no "admin" user yet).
+
+As an extra bonus this will automatically mark the database using the
+``django_db`` mark.
+
+``django_user_model``
+~~~~~~~~~~~~~~~~~~~~~
+
+The user model used by Django. This handles different versions of Django.
+
+``django_username_field``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The field name used for the username on the user model.
+
 ``db``
 ~~~~~~~
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -11,13 +11,14 @@ import pytest
 
 from .django_compat import is_django_unittest
 from .fixtures import (_django_db_setup, db, transactional_db, client,
-                       admin_client, rf, settings, live_server,
+                       django_user_model, django_username_field,
+                       admin_user, admin_client, rf, settings, live_server,
                        _live_server_helper)
 
 from .lazy_django import skip_if_no_django, django_settings_is_configured
 
 
-(_django_db_setup, db, transactional_db, client, admin_client, rf,
+(_django_db_setup, db, transactional_db, client, admin_user, admin_client, rf,
  settings, live_server, _live_server_helper)
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -35,6 +35,15 @@ def test_admin_client_no_db_marker(admin_client):
     assert force_text(resp.content) == 'You are an admin'
 
 
+@pytest.mark.django_db
+def test_admin_user(admin_user, django_user_model):
+    assert isinstance(admin_user, django_user_model)
+
+
+def test_admin_user_no_db_marker(admin_user, django_user_model):
+    assert isinstance(admin_user, django_user_model)
+
+
 def test_rf(rf):
     assert isinstance(rf, RequestFactory)
 


### PR DESCRIPTION
This refactors the admin user out of the `admin_client` fixture and
provides it separately.

I have not used the `client` fixture with `admin_client` to keep them separate.
Maybe that should get done for `admin_user`, too?
