### PR TITLE
fix typos and add $VIRTUAL_ENV suggestion

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -104,7 +104,7 @@ database will automatically be re-created.
 ``--create-db`` - force re creation of the test database
 --------------------------------------------------------
 When used with ``--reuse-db``, this option will re-create the database,
-regardless of wheter it exists or not.
+regardless of whether it exists or not.
 
 Example work flow with ``--reuse-db`` and ``--create-db``.
 -----------------------------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -33,7 +33,7 @@ Activate a specific locale in your project's ``conftest.py``::
 
 My tests are not being picked up when I run py.test from the root directory. Why not?
 -------------------------------------------------------------------------------------
- By default, py.test looks for tests in files named ``test_*.py`` (note that this is not the same as ``test*.py``). 
+ By default, py.test looks for tests in files named ``test_*.py`` (note that this is not the same as ``test*.py``).
  If you have your tests in files with other names, they will not be collected. It is common to put tests under
  ``app_directory/tests/views.py``. To find those tests, create a ``pytest.ini`` file in your
  project root with the contents::
@@ -49,15 +49,15 @@ How can I avoid having to type DJANGO_SETTINGS_MODULE=... to run the tests?
 
 If you are using virtualenvwrapper, use a postactivate script to set ``DJANGO_SETTINGS_MODULE`` when your project's virtualenv is activated.
 
-This snippet should do the trick (make sure to replace ``YOUR_VIRTUALENV_NAME``)::
+This snippet should do the trick (replace ``yourproject.settings`` and make sure your virtualenv is active)::
 
-    echo "export DJANGO_SETTINGS_MODULE=yourproject.settings" >> $WORKON_HOME/YOUR_VIRTUALENV_NAME/bin/postactivate
+    echo "export DJANGO_SETTINGS_MODULE=yourproject.settings" >> $VIRTUAL_ENV/bin/postactivate
 
 
-How does South and pytest-django play together?
+How do South and pytest-django play together?
 ------------------------------------------------
 
-Djangos own syncdb will always be used to create the test database, regardless of wheter South is present or not.
+Django's own syncdb will always be used to create the test database, regardless of whether South is present or not.
 
 
 Does this work with the pytest-xdist plugin?


### PR DESCRIPTION
I noticed a couple typos in the docs.

In addition, you can use the `$VIRTUAL_ENV` environment variable to get the base directory of a virtual environment without having to specify its name.
