### PR TITLE
Relates to #119 for django 1.7 settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 _build
 .tox
 .DS_Store
+.ropeproject
 *~
 .env
 /.coverage.*

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -73,6 +73,12 @@ def _load_settings(config, options):
             # Install the django-configurations importer
             import configurations.importer
             configurations.importer.install()
+        try:
+            from .compat import setup
+            setup()
+        except ImportError:
+            pass  # Ignore bad settings modules at this point
+
 
 
 if pytest.__version__[:3] >= "2.4":


### PR DESCRIPTION
Added ropeproject folders to gitignore,
Added call to setup() during loading. This FAILS some tests, but I'm
posting it up to get some help with those failures.
