### PR TITLE
Do not create empty files with SQLite ':memory:' with `django_testdir`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,10 @@ from .db_helpers import (create_empty_production_database, get_db_engine,
 
 @pytest.fixture(scope='function')
 def django_testdir(request, testdir, monkeypatch):
-    if get_db_engine() in ('mysql', 'postgresql_psycopg2', 'sqlite3'):
-        # Django requires the production database to exists..
+    db_engine = get_db_engine()
+    if db_engine in ('mysql', 'postgresql_psycopg2') \
+            or (db_engine == 'sqlite3' and DB_NAME != ':memory:'):
+        # Django requires the production database to exist.
         create_empty_production_database()
 
     if hasattr(request.node.cls, 'db_settings'):

--- a/tests/db_helpers.py
+++ b/tests/db_helpers.py
@@ -7,8 +7,12 @@ from django.conf import settings
 
 from .compat import force_text
 
-DB_NAME = settings.DATABASES['default']['NAME'] + '_db_test'
-TEST_DB_NAME = 'test_' + DB_NAME
+DB_NAME = settings.DATABASES['default']['NAME']
+if DB_NAME != ':memory:':
+    DB_NAME += '_db_test'
+    TEST_DB_NAME = 'test_' + DB_NAME
+else:
+    TEST_DB_NAME = DB_NAME
 
 
 def get_db_engine():


### PR DESCRIPTION
I have noticed that there are `test_:memory:_db_test` files in the testdirs created from the `django_testdir` fixture.
- Keep ':memory:' for DB_NAME and TEST_DB_NAME with SQLite in-memory DB.
- Skip `create_empty_production_database` with DB_NAME == ':memory:'.
