### PR TITLE
Merge client environ setup from Django master

### DIFF
--- a/pytest_django/client.py
+++ b/pytest_django/client.py
@@ -18,21 +18,21 @@ class PytestDjangoRequestFactory(VanillaRequestFactory):
     """
     def request(self, **request):
         environ = {
-            'HTTP_COOKIE':       self.cookies.output(header='', sep='; '),
-            'PATH_INFO':         '/',
-            'REMOTE_ADDR':       '127.0.0.1',
-            'REQUEST_METHOD':    'GET',
-            'SCRIPT_NAME':       '',
-            'SERVER_NAME':       'testserver',
-            'SERVER_PORT':       '80',
-            'SERVER_PROTOCOL':   'HTTP/1.1',
-            'wsgi.version':      (1, 0),
-            'wsgi.url_scheme':   'http',
-            'wsgi.input':        FakePayload(''),
-            'wsgi.errors':       self.errors,
+            'HTTP_COOKIE': self.cookies.output(header='', sep='; '),
+            'PATH_INFO': str('/'),
+            'REMOTE_ADDR': str('127.0.0.1'),
+            'REQUEST_METHOD': str('GET'),
+            'SCRIPT_NAME': str(''),
+            'SERVER_NAME': str('testserver'),
+            'SERVER_PORT': str('80'),
+            'SERVER_PROTOCOL': str('HTTP/1.1'),
+            'wsgi.version': (1, 0),
+            'wsgi.url_scheme': str('http'),
+            'wsgi.input': FakePayload(b''),
+            'wsgi.errors': self.errors,
             'wsgi.multiprocess': True,
-            'wsgi.multithread':  False,
-            'wsgi.run_once':     False,
+            'wsgi.multithread': False,
+            'wsgi.run_once': False,
         }
         environ.update(self.defaults)
         environ.update(request)


### PR DESCRIPTION
I have noticed and compared it because of flake8 issues, and the only
non-whitespace changes are the addition of `str()` and `b''` wrappers.
