### PR TITLE
setup.py: Mention the 3-clause BSD license in our metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     maintainer="Andreas Pelme",
     maintainer_email="andreas@pelme.se",
     url='http://pytest-django.readthedocs.org/',
+    license='BSD-3-Clause',
     packages=['pytest_django'],
     long_description=read('README.rst'),
     install_requires=['pytest>=2.5'],


### PR DESCRIPTION
I don't know if PyPI has a convention for naming these, but that's
what the Open Source Initiative calls this one [1].  However, the text
is a bit different from the official upstream version which has:

  3. Neither the name of the copyright holder nor the names of its
     contributors may be used...

instead of the local:

  * The names of its contributors may not be used...

There's also an "COPYRIGHT HOLDER" -> "COPYRIGHT OWNER" change in the
local disclaimer.

It would be nice if we could stick to the standard upstream phrasing.

[1]: http://opensource.org/licenses/BSD-3-Clause