### PR TITLE
Delay setting up Django, so e.g. pytest-cov can start coverage first.

### DIFF
--- a/pytest_django/lazy_django.py
+++ b/pytest_django/lazy_django.py
@@ -24,8 +24,30 @@ def django_settings_is_configured():
     # always be loaded.
     from django.conf import settings
     assert settings.configured is True
+    setup_django()
     return True
 
 
 def get_django_version():
     return __import__('django').VERSION
+
+
+_django_setup_done = False
+
+
+def setup_django():
+    global _django_setup_done
+    import django
+
+    if _django_setup_done:
+        return
+
+    if hasattr(django, 'setup'):
+        django.setup()
+    else:
+        # Emulate Django 1.7 django.setup() with get_models
+        from django.db.models import get_models
+
+        get_models()
+
+    _django_setup_done = True

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -113,18 +113,6 @@ def _add_django_project_to_path(args):
     return PROJECT_NOT_FOUND
 
 
-def _setup_django():
-    import django
-
-    if hasattr(django, 'setup'):
-        django.setup()
-    else:
-        # Emulate Django 1.7 django.setup() with get_models
-        from django.db.models import get_models
-
-        get_models()
-
-
 def _parse_django_find_project_ini(x):
     if x in (True, False):
         return x
@@ -194,14 +182,6 @@ def pytest_load_initial_conftests(early_config, parser, args):
 
         with _handle_import_error(_django_project_scan_outcome):
             settings.DATABASES
-
-        _setup_django()
-
-
-@pytest.mark.trylast
-def pytest_configure():
-    if django_settings_is_configured():
-        _setup_django()
 
 
 @pytest.fixture(autouse=True, scope='session')

--- a/tests/test_django_settings_module.py
+++ b/tests/test_django_settings_module.py
@@ -260,6 +260,6 @@ def test_django_setup_sequence(django_testdir):
         """)
 
     result = django_testdir.runpytest('-s', '--tb=line')
-    result.stdout.fnmatch_lines(['*IMPORT: populating=True,ready=False*'])
+    result.stdout.fnmatch_lines(['*IMPORT: populating=False,ready=False*'])
     result.stdout.fnmatch_lines(['*READY(): populating=True*'])
     result.stdout.fnmatch_lines(['*TEST: populating=False,ready=True*'])


### PR DESCRIPTION
Here's my proposed fix for #175. I had to change one test, but since the test didn't explain _why_ it's important for `django.setup()` to be called so early, I don't know if that change in behavior is a problem or not.

Due to #177 I didn't do a full tox run locally, but tests passed on the envs I tried. Hopefully Travis will spot any issues.
