### PR TITLE
Fix clobbering of real database by tests

### DIFF
--- a/pytest_django/db_reuse.py
+++ b/pytest_django/db_reuse.py
@@ -20,6 +20,7 @@ def test_database_exists_from_previous_run(connection):
 
     orig_db_name = connection.settings_dict['NAME']
     connection.settings_dict['NAME'] = test_db_name
+    connection.connection = None # force reconnection
 
     # With SQLite memory databases the db never exists.
     if connection.settings_dict['NAME'] == ':memory:':


### PR DESCRIPTION
Force disconnection if a database is already connected when patching for DB reuse.

DjangoCMS opens database connections very early, to set up URL routing, before
pytest has time to patch the database name to use the test database. Thus the
connection is already open and changing the NAME has no effect, so the real
database gets clobbered instead of the test one.

This isn't easy to trigger - I've only just noticed it and I've been using
DjangoCMS together with pytest-django for several projects. I don't yet know
what causes it. But because it's so catastrophic, I think we ought to put some
protection against it in place, hence this patch.