### PR TITLE
is_django_unittest gives false negatives during pytest_collection_modifyitems

### DIFF
--- a/pytest_django/django_compat.py
+++ b/pytest_django/django_compat.py
@@ -1,6 +1,5 @@
 # Note that all functions here assume django is available.  So ensure
 # this is the case before you call them.
-import sys
 
 
 def is_django_unittest(item):

--- a/pytest_django/django_compat.py
+++ b/pytest_django/django_compat.py
@@ -10,13 +10,7 @@ def is_django_unittest(item):
     except ImportError:
         from django.test import TestCase
 
-    if not hasattr(item, 'obj'):
+    if not hasattr(item, 'cls') or item.cls is None:
         return False
 
-    if sys.version_info < (3, 0):
-        return (hasattr(item.obj, 'im_class') and
-                issubclass(item.obj.im_class, TestCase))
-
-    return (hasattr(item.obj, '__self__') and
-            hasattr(item.obj.__self__, '__class__') and
-            issubclass(item.obj.__self__.__class__, TestCase))
+    return issubclass(item.cls, TestCase)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,3 +124,11 @@ def django_testdir_initial(django_testdir):
         }]""")
 
     return django_testdir
+
+
+def pytest_collection_modifyitems(items):
+    from test_django_compat import TestSimple
+    from pytest_django import django_compat
+    for item in items:
+        if hasattr(item, 'cls') and item.cls == TestSimple:
+            assert django_compat.is_django_unittest(item)

--- a/tests/test_django_compat.py
+++ b/tests/test_django_compat.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pytest_django.django_compat import is_django_unittest
+
+from django.test import TestCase
+
+@pytest.fixture(scope="session", autouse=True)
+def check_is_django_unitttest(request):
+    for item in request.node.items:
+        if hasattr(item, 'cls') and item.cls == TestSimple:
+            assert is_django_unittest(item)
+
+
+class TestSimple(TestCase):
+    def test_nothing(self):
+        pass
+

--- a/tests/test_django_compat.py
+++ b/tests/test_django_compat.py
@@ -4,6 +4,7 @@ from pytest_django.django_compat import is_django_unittest
 
 from django.test import TestCase
 
+
 @pytest.fixture(scope="session", autouse=True)
 def check_is_django_unitttest(request):
     for item in request.node.items:
@@ -14,4 +15,3 @@ def check_is_django_unitttest(request):
 class TestSimple(TestCase):
     def test_nothing(self):
         pass
-


### PR DESCRIPTION
`django_compat.is_django_unittest` would give false negatives during test collection. This made it hard for me to filter db tests from non-db test.

I'm not thrilled with what amounts to putting a test inside the conftest module, but I'm not sure if there's another way to test this? The `@pytest.fixture` I added was passing with the original code. Only the change to conftest exposed this problem (which I how I ran across it in the first place).