### PR TITLE
Create --nomigrations option to disable Django 1.7 migrations

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -120,3 +120,11 @@ A good way to use ``--reuse-db`` and ``--create-db`` can be:
 
 * When you alter your database schema, run ``py.test --create-db``, to force
   re-creation of the test database.
+
+``--nomigrations`` - Disable Django 1.7+ migrations
+--------------------------------------------------------------
+
+Using ``--nomigrations`` will `disable Django 1.7+ migrations <https://gist.github.com/NotSqrt/5f3c76cd15e40ef62d09>`_
+and create the database inspecting the all app models (the default behavior of
+Django until version 1.6). It may be faster when there are several migrations
+to run in the database setup.

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -125,6 +125,6 @@ A good way to use ``--reuse-db`` and ``--create-db`` can be:
 --------------------------------------------------------------
 
 Using ``--nomigrations`` will `disable Django 1.7+ migrations <https://gist.github.com/NotSqrt/5f3c76cd15e40ef62d09>`_
-and create the database inspecting the all app models (the default behavior of
+and create the database inspecting all app models (the default behavior of
 Django until version 1.6). It may be faster when there are several migrations
 to run in the database setup.

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -135,7 +135,7 @@ def _handle_south():
 def _disable_native_migrations():
     from django import get_version
 
-    if get_version() > '1.7':
+    if get_version() >= '1.7':
         from django.conf import settings
         from .migrations import DisableMigrations
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -40,6 +40,9 @@ def _django_db_setup(request,
 
     _handle_south()
 
+    if request.config.getvalue('nomigrations'):
+        _disable_native_migrations()
+
     with _django_cursor_wrapper:
         # Monkey patch Django's setup code to support database re-use
         if request.config.getvalue('reuse_db'):
@@ -127,6 +130,16 @@ def _handle_south():
             south.hacks.django_1_0.SkipFlushCommand = SkipFlushCommand
 
             patch_for_test_db_setup()
+
+
+def _disable_native_migrations():
+    from django import get_version
+
+    if get_version() > '1.7':
+        from django.conf import settings
+        from .migrations import DisableMigrations
+
+        settings.MIGRATION_MODULES = DisableMigrations()
 
 
 # ############### User visible fixtures ################

--- a/pytest_django/migrations.py
+++ b/pytest_django/migrations.py
@@ -1,0 +1,8 @@
+# code snippet copied from https://gist.github.com/NotSqrt/5f3c76cd15e40ef62d09
+class DisableMigrations(object):
+
+    def __contains__(self, item):
+        return True
+
+    def __getitem__(self, item):
+        return "notmigrations"

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -46,6 +46,9 @@ def pytest_addoption(parser):
     group._addoption('--dc',
                      action='store', type='string', dest='dc', default=None,
                      help='Set DJANGO_CONFIGURATION.')
+    group._addoption('--nomigrations',
+                     action='store_true', dest='nomigrations', default=False,
+                     help='Disable Django 1.7 migrations on test setup')
     parser.addini(CONFIGURATION_ENV,
                   'django-configurations class to use by pytest-django.')
     group._addoption('--liveserver', default=None,

--- a/tests/test_db_setup.py
+++ b/tests/test_db_setup.py
@@ -10,6 +10,7 @@ from pytest_django_test.db_helpers import (db_exists, drop_database,
 skip_on_python32 = pytest.mark.skipif(sys.version_info[:2] == (3, 2),
                                       reason='xdist is flaky with Python 3.2')
 
+
 def test_db_reuse_simple(django_testdir):
     "A test for all backends to check that `--reuse-db` works."
     django_testdir.create_test_module('''
@@ -363,7 +364,9 @@ class TestNativeMigrations(object):
                     migrations.CreateModel(
                         name='Item',
                         fields=[
-                            ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True)),
+                            ('id', models.AutoField(serialize=False,
+                                                    auto_created=True,
+                                                    primary_key=True)),
                             ('name', models.CharField(max_length=100)),
                         ],
                         options={


### PR DESCRIPTION
When there are several migrations to run, the database setup can be very slow. This pull request uses [a hack](https://gist.github.com/NotSqrt/5f3c76cd15e40ef62d09) to disable Django 1.7 migrations when the option `--nomigrations` is given.

It should not be a problem when you use `--reuse-db` in your workflow, but the `--nomigrations` flag should help who needs / prefers to create the database on every run.

It seems that [until Django 1.9](https://groups.google.com/forum/#!topic/django-developers/PWPj3etj3-U) is safe to use this hack -- I hope we have another way to do it then. 

There's also a [plugin for manage.py](https://github.com/henriquebastos/django-test-without-migrations) to do it.

My tests took 120 seconds before and are taking just 10 seconds now, so I hope it gets merged.