### PR TITLE
setup.cfg: use settings_sqlite_file for DSM

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # --strict: warnings become errors.
 # -r fEsxXw: show extra test summary info for everything.
 addopts = --ignore lib/ --ignore build/ --ignore include/ --ignore local/ --ignore src/ --strict -r fEsxXw
-DJANGO_SETTINGS_MODULE = pytest_django_test.settings_sqlite
+DJANGO_SETTINGS_MODULE = pytest_django_test.settings_sqlite_file
 
 [wheel]
 universal = 1


### PR DESCRIPTION
This skips less tests by default.