### PR TITLE
TBD: Look at os.environ before early_config

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -172,13 +172,13 @@ def pytest_load_initial_conftests(early_config, parser, args):
 
     # Configure DJANGO_SETTINGS_MODULE
     ds = (options.ds or
-          early_config.getini(SETTINGS_MODULE_ENV) or
-          os.environ.get(SETTINGS_MODULE_ENV))
+          os.environ.get(SETTINGS_MODULE_ENV) or
+          early_config.getini(SETTINGS_MODULE_ENV))
 
     # Configure DJANGO_CONFIGURATION
     dc = (options.dc or
-          early_config.getini(CONFIGURATION_ENV) or
-          os.environ.get(CONFIGURATION_ENV))
+          os.environ.get(CONFIGURATION_ENV) or
+          early_config.getini(CONFIGURATION_ENV))
 
     if ds:
         os.environ[SETTINGS_MODULE_ENV] = ds

--- a/tests/test_django_configurations.py
+++ b/tests/test_django_configurations.py
@@ -50,22 +50,22 @@ def test_dc_env(testdir, monkeypatch):
 
 
 def test_dc_ini(testdir, monkeypatch):
-    monkeypatch.setenv('DJANGO_SETTINGS_MODULE', 'DO_NOT_USE')
-    monkeypatch.setenv('DJANGO_CONFIGURATION', 'DO_NOT_USE')
+    monkeypatch.setenv('DJANGO_SETTINGS_MODULE', 'tpkg.settings_env')
+    monkeypatch.setenv('DJANGO_CONFIGURATION', 'MySettings')
 
     testdir.makeini("""
        [pytest]
-       DJANGO_SETTINGS_MODULE = tpkg.settings_ini
-       DJANGO_CONFIGURATION = MySettings
+       DJANGO_SETTINGS_MODULE = DO_NOT_USE_ini
+       DJANGO_CONFIGURATION = DO_NOT_USE_ini
     """)
     pkg = testdir.mkpydir('tpkg')
-    settings = pkg.join('settings_ini.py')
+    settings = pkg.join('settings_env.py')
     settings.write(BARE_SETTINGS)
     testdir.makepyfile("""
         import os
 
         def test_ds():
-            assert os.environ['DJANGO_SETTINGS_MODULE'] == 'tpkg.settings_ini'
+            assert os.environ['DJANGO_SETTINGS_MODULE'] == 'tpkg.settings_env'
             assert os.environ['DJANGO_CONFIGURATION'] == 'MySettings'
     """)
     result = testdir.runpytest()

--- a/tests/test_django_settings_module.py
+++ b/tests/test_django_settings_module.py
@@ -36,10 +36,11 @@ def test_ds_env(testdir, monkeypatch):
 
 
 def test_ds_ini(testdir, monkeypatch):
-    monkeypatch.setenv('DJANGO_SETTINGS_MODULE', 'DO_NOT_USE')
+    "DSM env should override ini."
+    monkeypatch.setenv('DJANGO_SETTINGS_MODULE', 'tpkg.settings_ini')
     testdir.makeini("""\
        [pytest]
-       DJANGO_SETTINGS_MODULE = tpkg.settings_ini
+       DJANGO_SETTINGS_MODULE = DO_NOT_USE_ini
     """)
     pkg = testdir.mkpydir('tpkg')
     settings = pkg.join('settings_ini.py')


### PR DESCRIPTION
This breaks a lot of internal tests, which could be adjusted.

I think it makes more sense to prefer the current environment before the
config from (e.g.) setup.cfg.