### PR TITLE
Cleanup interaction with `live_server` and `transactional_db`

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -83,8 +83,6 @@ def _django_db_fixture_helper(transactional, request, _django_cursor_wrapper):
         request.addfinalizer(_django_cursor_wrapper.disable)
         request.addfinalizer(flushdb)
     else:
-        if 'live_server' in request.funcargnames:
-            return
         from django.test import TestCase
 
         _django_cursor_wrapper.enable()
@@ -158,7 +156,8 @@ def db(request, _django_db_setup, _django_cursor_wrapper):
     database setup will behave as only ``transactional_db`` was
     requested.
     """
-    if 'transactional_db' in request.funcargnames:
+    if 'transactional_db' in request.funcargnames \
+            or 'live_server' in request.funcargnames:
         return request.getfuncargvalue('transactional_db')
     return _django_db_fixture_helper(False, request, _django_cursor_wrapper)
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -118,15 +118,11 @@ class TestLiveServer:
 
     @pytest.fixture
     def item(self):
-        # This has not requested database access so should fail.
-        # Unfortunately the _live_server_helper autouse fixture makes this
-        # test work.
-        with pytest.raises(pytest.fail.Exception):
-            Item.objects.create(name='foo')
+        # This has not requested database access explicitly, but the
+        # live_server fixture auto-uses the transactional_db fixture.
+        Item.objects.create(name='foo')
 
-    @pytest.mark.xfail
     def test_item(self, item, live_server):
-        # test should fail/pass in setup
         pass
 
     @pytest.fixture


### PR DESCRIPTION
This also removes a test marked as `xfail`, which is not supposed to fail as far as I understand.

@pelme 
Can you confirm that the test should not have been expected to fail in the first place?