### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ matrix:
     - env: TESTENV=python3.4-master-postgres
     - env: TESTENV=python3.4-master-sqlite
     - env: TESTENV=python3.4-master-sqlite_file
+before_install:
+  # Wrap "pip" with "travis_retry" to retry on network failures.
+  - pip() { travis_retry command pip "$@"; }
 install:
   - pip install tox
 script: tox -e $TESTENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,18 @@ env:
   - TESTENV=checkqa-python3.4
   - TESTENV=checkqa-pypy
   - TESTENV=checkqa-pypy3
+matrix:
+  allow_failures:
+    - env: TESTENV=pypy-master-sqlite_file
+    - env: TESTENV=pypy3-master-sqlite_file
+    - env: TESTENV=python2.7-master-mysql_innodb
+    - env: TESTENV=python2.7-master-mysql_myisam
+    - env: TESTENV=python2.7-master-sqlite_file
+    - env: TESTENV=python3.2-master-sqlite_file
+    - env: TESTENV=python3.3-master-sqlite_file
+    - env: TESTENV=python3.4-master-postgres
+    - env: TESTENV=python3.4-master-sqlite
+    - env: TESTENV=python3.4-master-sqlite_file
 install:
   - pip install tox
 script: tox -e $TESTENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Use container-based environment (faster startup, allows caches).
+sudo: false
 language: python
 python:
   - "3.4"

--- a/generate_configurations.py
+++ b/generate_configurations.py
@@ -220,6 +220,9 @@ def make_travis_yml(envs):
         matrix:
           allow_failures:
         %(allow_failures)s
+        before_install:
+          # Wrap "pip" with "travis_retry" to retry on network failures.
+          - pip() { travis_retry command pip "$@"; }
         install:
           - pip install tox
         script: tox -e $TESTENV

--- a/generate_configurations.py
+++ b/generate_configurations.py
@@ -209,6 +209,8 @@ def make_tox_ini(envs, default_envs):
 
 def make_travis_yml(envs):
     contents = dedent("""
+        # Use container-based environment (faster startup, allows caches).
+        sudo: false
         language: python
         python:
           - "%(RUN_PYTHON)s"

--- a/generate_configurations.py
+++ b/generate_configurations.py
@@ -217,6 +217,9 @@ def make_travis_yml(envs):
         env:
         %(testenvs)s
         %(checkenvs)s
+        matrix:
+          allow_failures:
+        %(allow_failures)s
         install:
           - pip install tox
         script: tox -e $TESTENV
@@ -224,10 +227,14 @@ def make_travis_yml(envs):
     testenvs = '\n'.join('  - TESTENV=%s' % testenv_name(env) for env in envs)
     checkenvs = '\n'.join('  - TESTENV=checkqa-%s' %
                           python for python in PYTHON_VERSIONS)
+    allow_failures = '\n'.join('    - env: TESTENV=%s' %
+                               testenv_name(env) for env in envs
+                               if env.django_version == 'master')
 
     return contents % {
         'testenvs': testenvs,
         'checkenvs': checkenvs,
+        'allow_failures': allow_failures,
         'RUN_PYTHON': RUN_PYTHON,
     }
 


### PR DESCRIPTION
`sudo: false` makes sense (to enable a container based environment, which is faster and has more features).

But I don't now if we want to allow failure of Django master?

Another interesting option (when we'll use the allowed failures) is `fast_finish`: http://docs.travis-ci.com/user/build-configuration/#Fast-finishing