### PR TITLE
db fixture: fixed docstring

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -146,11 +146,12 @@ def _disable_native_migrations():
 def db(request, _django_db_setup, _django_cursor_wrapper):
     """Require a django test database
 
-    This database will be setup with the default fixtures and will
-    have the transaction management disabled.  At the end of the test
-    the transaction will be rolled back to undo any changes to the
-    database.  This is more limited than the ``transactional_db``
-    resource but faster.
+    This database will be setup with the default fixtures and will have
+    the transaction management disabled. At the end of the test the outer
+    transaction that wraps the test itself will be rolled back to undo any
+    changes to the database (in case the backend supports transactions).
+    This is more limited than the ``transactional_db`` resource but
+    faster.
 
     If both this and ``transactional_db`` are requested then the
     database setup will behave as only ``transactional_db`` was


### PR DESCRIPTION
It doesn't look like the `db` fixture docstring makes much sense. First it says it will setup the DB without transaction support and then it says it will roll back changes at the end of the transaction. My understanding is there are no transactions and therefore the second sentence of the existing docstring must go away.