### PR TITLE
Use .tar.gz instead of .zip to work around pip bug

### DIFF
--- a/generate_configurations.py
+++ b/generate_configurations.py
@@ -36,8 +36,8 @@ DJANGO_REQUIREMENTS = {
     '1.5': 'Django>=1.5,<1.6',
     '1.6': 'Django>=1.6,<1.7',
     '1.7': 'Django>=1.7,<1.8',
-    '1.8': 'https://github.com/django/django/archive/stable/1.8.x.zip',
-    'master': 'https://github.com/django/django/archive/master.zip',
+    '1.8': 'https://github.com/django/django/archive/stable/1.8.x.tar.gz',
+    'master': 'https://github.com/django/django/archive/master.tar.gz',
 }
 
 TOX_TESTENV_TEMPLATE = dedent("""

--- a/tox.ini
+++ b/tox.ini
@@ -233,7 +233,7 @@ basepython = pypy
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     south==1.0.2
 setenv =
@@ -248,7 +248,7 @@ basepython = pypy
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     south==1.0.2
 setenv =
@@ -263,7 +263,7 @@ basepython = pypy
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     south==1.0.2
 setenv =
@@ -278,7 +278,7 @@ basepython = pypy
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     south==1.0.2
 setenv =
@@ -377,7 +377,7 @@ basepython = pypy3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -391,7 +391,7 @@ basepython = pypy3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -405,7 +405,7 @@ basepython = pypy3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -419,7 +419,7 @@ basepython = pypy3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1163,7 +1163,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     south==1.0.2
     mysql-python==1.2.5
@@ -1180,7 +1180,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     south==1.0.2
     mysql-python==1.2.5
@@ -1197,7 +1197,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     south==1.0.2
     psycopg2==2.5.2
@@ -1213,7 +1213,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     south==1.0.2
 setenv =
@@ -1228,7 +1228,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     south==1.0.2
 setenv =
@@ -1244,7 +1244,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     south==1.0.2
     mysql-python==1.2.5
@@ -1261,7 +1261,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     south==1.0.2
     mysql-python==1.2.5
@@ -1278,7 +1278,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     south==1.0.2
     psycopg2==2.5.2
@@ -1294,7 +1294,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     south==1.0.2
 setenv =
@@ -1309,7 +1309,7 @@ basepython = python2.7
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     south==1.0.2
 setenv =
@@ -1457,7 +1457,7 @@ basepython = python3.2
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     psycopg2==2.5.2
 setenv =
@@ -1472,7 +1472,7 @@ basepython = python3.2
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1486,7 +1486,7 @@ basepython = python3.2
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1501,7 +1501,7 @@ basepython = python3.2
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     psycopg2==2.5.2
 setenv =
@@ -1516,7 +1516,7 @@ basepython = python3.2
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1530,7 +1530,7 @@ basepython = python3.2
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1677,7 +1677,7 @@ basepython = python3.3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     psycopg2==2.5.2
 setenv =
@@ -1692,7 +1692,7 @@ basepython = python3.3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1706,7 +1706,7 @@ basepython = python3.3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1721,7 +1721,7 @@ basepython = python3.3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     psycopg2==2.5.2
 setenv =
@@ -1736,7 +1736,7 @@ basepython = python3.3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1750,7 +1750,7 @@ basepython = python3.3
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1897,7 +1897,7 @@ basepython = python3.4
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
     psycopg2==2.5.2
 setenv =
@@ -1912,7 +1912,7 @@ basepython = python3.4
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1926,7 +1926,7 @@ basepython = python3.4
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/stable/1.8.x.zip
+    https://github.com/django/django/archive/stable/1.8.x.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1941,7 +1941,7 @@ basepython = python3.4
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
     psycopg2==2.5.2
 setenv =
@@ -1956,7 +1956,7 @@ basepython = python3.4
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}
@@ -1970,7 +1970,7 @@ basepython = python3.4
 deps =
     pytest==2.6.4
     pytest-xdist==1.11
-    https://github.com/django/django/archive/master.zip
+    https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
      PYTHONPATH = {toxinidir}


### PR DESCRIPTION
This works around https://github.com/pypa/pip/issues/1698, where pip
fails to install the zip with unicode filenames on Python 2.