### PR TITLE
run migrations on test database if --reuse-db is set

### DIFF
--- a/pytest_django/db_reuse.py
+++ b/pytest_django/db_reuse.py
@@ -96,6 +96,7 @@ def create_test_db_with_reuse(self, verbosity=1, autoclobber=False,
     will not actually create a new database, but just reuse the
     existing.
     """
+    from django import VERSION as DJANGO_VERSION
     from django.core.management import call_command
 
     test_database_name = self._get_test_db_name()
@@ -113,13 +114,14 @@ def create_test_db_with_reuse(self, verbosity=1, autoclobber=False,
     if hasattr(self.connection.features, 'confirm'):
         self.connection.features.confirm()
 
-    call_command(
-        'migrate',
-        verbosity=max(verbosity - 1, 0),
-        interactive=False,
-        database=self.connection.alias,
-        run_syncdb=True,
-    )
+    if DJANGO_VERSION > (1, 7):
+        call_command(
+            'migrate',
+            verbosity=max(verbosity - 1, 0),
+            interactive=False,
+            database=self.connection.alias,
+            run_syncdb=True,
+        )
 
     return test_database_name
 

--- a/pytest_django/db_reuse.py
+++ b/pytest_django/db_reuse.py
@@ -96,6 +96,8 @@ def create_test_db_with_reuse(self, verbosity=1, autoclobber=False,
     will not actually create a new database, but just reuse the
     existing.
     """
+    from django.core.management import call_command
+
     test_database_name = self._get_test_db_name()
     self.connection.settings_dict['NAME'] = test_database_name
 
@@ -110,6 +112,14 @@ def create_test_db_with_reuse(self, verbosity=1, autoclobber=False,
     # See https://code.djangoproject.com/ticket/17760
     if hasattr(self.connection.features, 'confirm'):
         self.connection.features.confirm()
+
+    call_command(
+        'migrate',
+        verbosity=max(verbosity - 1, 0),
+        interactive=False,
+        database=self.connection.alias,
+        run_syncdb=True,
+    )
 
     return test_database_name
 


### PR DESCRIPTION
Run migrations on the test database(s) when ```--reuse-db``` options is enabled and the test database already exists.

This helps people with large (and slow) migration sets which otherwise would have to drop the test database or manually run the migrations on it.