### PR TITLE
WIP: use "db" with "live_server", not "transactional_db"

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -156,8 +156,7 @@ def db(request, _django_db_setup, _django_cursor_wrapper):
     database setup will behave as only ``transactional_db`` was
     requested.
     """
-    if 'transactional_db' in request.funcargnames \
-            or 'live_server' in request.funcargnames:
+    if 'transactional_db' in request.funcargnames:
         return request.getfuncargvalue('transactional_db')
     return _django_db_fixture_helper(False, request, _django_cursor_wrapper)
 
@@ -330,4 +329,4 @@ def _live_server_helper(request):
     function-scoped.
     """
     if 'live_server' in request.funcargnames:
-        request.getfuncargvalue('transactional_db')
+        request.getfuncargvalue('db')


### PR DESCRIPTION
"transactional_db" is slower and has drawbacks.  Using "db" instead
seems to work.

See also https://code.djangoproject.com/timeline?from=2014-10-13T05%3A15%3A40-05%3A00&precision=second.