### PR TITLE
Adds tests for invalid template variables

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -77,6 +77,23 @@ on what marks are and for notes on using_ them.
          assert 'Success!' in client.get('/some_url_defined_in_test_urls/')
 
 
+``pytest.mark.ignore_template_errors`` - ignore invalid template variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+..py:function:: pytest.mark.ignore_template_errors
+
+  If you run py.test using the ``--fail-on-template-vars`` option,
+  tests will fail should your templates contain any invalid variables.
+  This marker will disable this feature by setting ``settings.TEMPLATE_STRING_IF_INVALID=None``
+  or the ``string_if_invalid`` template option in Django>=1.7
+
+  Example usage::
+
+     @pytest.mark.ignore_template_errors
+     def test_something(client):
+         client('some-url-with-invalid-template-vars')
+
+
 Fixtures
 --------
 
@@ -86,7 +103,7 @@ More information on fixtures is available in the `py.test documentation
 
 
 ``rf`` - ``RequestFactory``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An instance of a `django.test.RequestFactory`_
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,6 +22,13 @@ the command line::
 See the `py.test documentation on Usage and invocations
 <http://pytest.org/latest/usage.html>`_ for more help on available parameters.
 
+Additional command line options
+-------------------------------
+
+``--fail-on-template-vars`` - fail for invalid variables in templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fail tests that render templates which make use of invalid template variables.
+
 Running tests in parallel with pytest-xdist
 -------------------------------------------
 pytest-django supports running tests on multiple processes to speed up test


### PR DESCRIPTION
Django catches all `VariableDoesNotExist` exceptions to replace
them in templates with a modifiable string that you can define in
your settings.
Sadly that doesn't allow you to find them in unit tests.

`_fail_for_invalid_template_variable` sets the setting
`TEMPLATE_STRING_IF_INVALID` to a custom class that not only fails
the current test but prints a pretty message including the template
name.

A new marker allows disabling this behavior, eg:

    @pytest.mark.ignore_template_errors
    def test_something():
        pass

This marker sets the setting to None, if you want it to be a string,
you can use the `settings` fixture to set it to your desired value.