### PR TITLE
Add a runner consumable by TEST_RUNNER

### DIFF
--- a/pytest_django/runner.py
+++ b/pytest_django/runner.py
@@ -1,0 +1,61 @@
+import os
+from optparse import make_option
+
+import pytest
+
+
+class PyTestRunner(object):
+    """
+    Runs py.test to discover and run tests.
+    """
+    option_list = (
+        make_option('-t', '--top-level-directory',
+            action='store', dest='top_level', default=None,
+            help='Top level of project for unittest discovery.'),
+        make_option('-p', '--pattern', action='store', dest='pattern',
+            default="test*.py",
+            help='The test matching pattern. Defaults to test*.py.'),
+        make_option('-k', '--keepdb',
+            action='store_true', dest='keepdb', default=False,
+            help='Preserves the test DB between runs.'),
+    )
+
+    def __init__(self, pattern=None, top_level=None, verbosity=1,
+                 interactive=True, failfast=False, keepdb=False, **kwargs):
+        if pattern and pattern != 'test*.py':
+            # TODO: implement
+            raise NotImplementedError('Testing with a file pattern is not '
+                                      'implemented.')
+        if top_level is not None:
+            # TODO: implement
+            raise NotImplementedError('Specifying the top_level is not '
+                                      'implemented.')
+        self.verbosity = verbosity
+        self.interactive = interactive
+        self.failfast = failfast
+        self.keepdb = keepdb
+
+        # TODO: Make this an option
+        self.ds = os.environ['DJANGO_SETTINGS_MODULE']
+
+    def run_tests(self, test_labels, extra_tests=None, **kwargs):
+        if test_labels:
+            # TODO: implement
+            raise NotImplementedError('test_labels is not implemented.')
+        if extra_tests is not None:
+            # TODO: implement
+            raise NotImplementedError('extra_tests is not implemented.')
+
+        # Translate arguments
+        argv = ['--ds', self.ds]
+        if self.verbosity == 0:
+            argv.append('--quiet')
+        if self.verbosity == 2:
+            argv.append('--verbose')
+        if self.failfast:
+            argv.append('--exitfirst')
+        if self.keepdb:
+            argv.append('--nomigrations')
+
+        # Run py.test
+        pytest.main(argv)

--- a/pytest_django/runner.py
+++ b/pytest_django/runner.py
@@ -39,6 +39,9 @@ class PyTestRunner(object):
         self.ds = os.environ['DJANGO_SETTINGS_MODULE']
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
+        """
+        Run py.test and returns the exitcode.
+        """
         if test_labels:
             # TODO: implement
             raise NotImplementedError('test_labels is not implemented.')
@@ -58,4 +61,4 @@ class PyTestRunner(object):
             argv.append('--nomigrations')
 
         # Run py.test
-        pytest.main(argv)
+        return pytest.main(argv)

--- a/pytest_django/runner.py
+++ b/pytest_django/runner.py
@@ -10,14 +10,14 @@ class PyTestRunner(object):
     """
     option_list = (
         make_option('-t', '--top-level-directory',
-            action='store', dest='top_level', default=None,
-            help='Top level of project for unittest discovery.'),
+                    action='store', dest='top_level', default=None,
+                    help='Top level of project for unittest discovery.'),
         make_option('-p', '--pattern', action='store', dest='pattern',
-            default="test*.py",
-            help='The test matching pattern. Defaults to test*.py.'),
+                    default="test*.py",
+                    help='The test matching pattern. Defaults to test*.py.'),
         make_option('-k', '--keepdb',
-            action='store_true', dest='keepdb', default=False,
-            help='Preserves the test DB between runs.'),
+                    action='store_true', dest='keepdb', default=False,
+                    help='Preserves the test DB between runs.'),
     )
 
     def __init__(self, pattern=None, top_level=None, verbosity=1,


### PR DESCRIPTION
This allows you to use Django's standard `manage.py test` to run your tests instead of making your collaborators switch to a new command. This can also help open source projects by allowing contributors to use the existing Django conventions they're already used to, since the alternative is that they run `manage.py test` normally and it shows ""

The implementation provides a light-weight translation of `manage.py test` options to `py.test` options. This includes `--verbosity 0` => `--quiet`, `--verbosity 2` => `--verbose`, `--failfast` => `--exitfirst`, and the upcoming Django 1.8 `--keepdb` => this project's `--nomigrations` equivalent.

Use it by adding the following line to your Django settings.py:

```py
TEST_RUNNER = 'pytest_django.runner.PyTestRunner'
```

Now you can run the familiar `manage.py test` and switch to `py.test` when you're ready.
