### PR TITLE
Revert "Added isort to requirements"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ tox
 wheel
 twine
 south
-isort


### PR DESCRIPTION
isort is not really required for the project. And it actually caused
some weird problem, because of its dependency on pies, where pies==2.6.5
installed pies2overrides for Python 3.

This reverts commit 0cc993549ee585c59f2783d171d1d3074f7d60db.

@pelme 
Any objections (you've added it)?