### PR TITLE
Skip Django setup and manage.py scanning with "pytest --help"

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -162,6 +162,9 @@ def pytest_load_initial_conftests(early_config, parser, args):
 
     options = parser.parse_known_args(args)
 
+    if options.version or options.help:
+        return
+
     django_find_project = _parse_django_find_project_ini(
         early_config.getini('django_find_project'))
 
@@ -200,12 +203,6 @@ def pytest_load_initial_conftests(early_config, parser, args):
         _setup_django()
 
 
-@pytest.mark.trylast
-def pytest_configure():
-    if django_settings_is_configured():
-        _setup_django()
-
-
 def pytest_runtest_setup(item):
 
     if django_settings_is_configured() and is_django_unittest(item):
@@ -234,6 +231,7 @@ def _django_test_environment(request):
         we need to follow this model.
     """
     if django_settings_is_configured():
+        _setup_django()
         from django.conf import settings
         from .compat import setup_test_environment, teardown_test_environment
         settings.DEBUG = False

--- a/tests/test_manage_py_scan.py
+++ b/tests/test_manage_py_scan.py
@@ -50,3 +50,18 @@ def test_django_project_scan_disabled_invalid_settings(django_testdir,
     result.stderr.fnmatch_lines(['*ImportError*DOES_NOT_EXIST*'])
     result.stderr.fnmatch_lines(['*pytest-django did not search for '
                                  'Django projects*'])
+
+
+@pytest.mark.django_project(project_root='django_project_root',
+                            create_manage_py=True)
+def test_django_project_found_invalid_settings_version(django_testdir, monkeypatch):
+    """Invalid DSM should not cause an error with --help or --version."""
+    monkeypatch.setenv('DJANGO_SETTINGS_MODULE', 'DOES_NOT_EXIST')
+
+    result = django_testdir.runpytest('django_project_root', '--version')
+    assert result.ret == 0
+    result.stderr.fnmatch_lines(['*This is pytest version*'])
+
+    result = django_testdir.runpytest('django_project_root', '--help')
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(['*usage:*'])


### PR DESCRIPTION
With `pytest --version` and `pytest --help` pytest-django should not
throw an error (ImportError) in case of invalid DSM settings etc.

This removes hooking into `pytest_configure` altogether, and moves the
late call do `_setup_django` into the session-scoped autoload fixture instead.

Fixes https://github.com/pytest-dev/pytest-django/issues/235