### PR TITLE
Fix case when User model is based on email and has no username

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -241,21 +241,30 @@ def admin_user(db, django_user_model, django_username_field):
     try:
         user = UserModel._default_manager.get(**{username_field: 'admin'})
     except UserModel.DoesNotExist:
-        extra_fields = {}
-        if username_field != 'username':
-            extra_fields[username_field] = 'admin'
+        usermodel_fields = UserModel._meta.get_all_field_names()
+
+        extra_fields = {django_username_field: 'admin'}
+        if 'username' in usermodel_fields:
+            # django.contrib.auth.UserManager expects a username field to be
+            # present, even if a different USERNAME_FIELD is set.
+            extra_fields['username'] = 'admin'
+        if 'email' in usermodel_fields:
+            # Handle both email field required for default UserManager and
+            # cases where USERNAME_FIELD is the email.
+            extra_fields['email'] = 'admin@example.com'
+
         user = UserModel._default_manager.create_superuser(
-            'admin', 'admin@example.com', 'password', **extra_fields)
+            password='password', **extra_fields)
     return user
 
 
 @pytest.fixture()
-def admin_client(db, admin_user):
+def admin_client(db, admin_user, django_username_field):
     """A Django test client logged in as an admin user."""
     from django.test.client import Client
 
     client = Client()
-    client.login(username=admin_user.username, password='password')
+    client.login(username=getattr(admin_user, django_username_field), password='password')
     return client
 
 


### PR DESCRIPTION
This fixes usecases whith a custom User model that uses an email address as the username, but has no username field present. An example of such model is present in the [Django doc on customizing authentication](https://docs.djangoproject.com/en/1.7/topics/auth/customizing/#a-full-example).

The function `def admin_client(...)` requires access to `django_username_field` as `admin_user.username` is not valid if the username field is absent.

This patch is based on current master and #241.
