### PR TITLE
Ensure the overridden URL conf is loaded

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -329,10 +329,13 @@ def _django_set_urlconf(request):
     if marker:
         skip_if_no_django()
         import django.conf
-        from django.core.urlresolvers import clear_url_caches
+        from django.core.urlresolvers import clear_url_caches, set_urlconf
 
         validate_urls(marker)
         original_urlconf = django.conf.settings.ROOT_URLCONF
+        set_urlconf(marker.urls)
+        # We have to override `ROOT_URLCONF` as Django's core handler
+        # calls set_urlconf anyway!
         django.conf.settings.ROOT_URLCONF = marker.urls
         clear_url_caches()
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -3,8 +3,6 @@ from django.conf import settings
 
 from pytest_django_test.compat import force_text
 
-pytestmark = pytest.mark.urls('pytest_django_test.urls_overridden')
-
 try:
     from django.core.urlresolvers import is_valid_path
 except ImportError:
@@ -24,11 +22,44 @@ except ImportError:
             return False
 
 
+@pytest.mark.urls('pytest_django_test.urls_overridden')
 def test_urls():
     assert settings.ROOT_URLCONF == 'pytest_django_test.urls_overridden'
     assert is_valid_path('/overridden_url/')
 
 
+@pytest.mark.urls('pytest_django_test.urls_overridden')
 def test_urls_client(client):
     response = client.get('/overridden_url/')
     assert force_text(response.content) == 'Overridden urlconf works!'
+
+
+def test_passive_url_request(testdir):
+    testdir.makepyfile(myurls="""
+        try:
+            from django.conf.urls import patterns, url
+        except ImportError:
+            from django.conf.urls.defaults import patterns, url
+
+        def fake_view(request):
+            pass
+
+        urlpatterns = patterns('', url(r'first/$', fake_view, name='first'))
+    """)
+
+    testdir.makepyfile("""
+        from django.core.urlresolvers import reverse, NoReverseMatch
+        import pytest
+
+        def test_something_else(client):
+            # Doesn't matter what we do, perform an action that causes
+            # django to load the URL conf
+            client.get('/')
+
+        @pytest.mark.urls('myurls')
+        def test_something():
+            reverse('first')
+    """)
+
+    result = testdir.runpytest()
+    assert result.ret == 0


### PR DESCRIPTION
If we override the `ROOT_URLCONF` without activating the new config, then performing an action which doesn't force django to load the new url conf will fail.

I've taken the liberty of cloning the quarantined url conf from https://github.com/pytest-dev/pytest-django/pull/242, perhaps once (/ if) they're both accepted this can be improved.