### PR TITLE
Use Django's `--keepdb` with Django 1.8+

### DIFF
--- a/pytest_django/db_reuse.py
+++ b/pytest_django/db_reuse.py
@@ -95,6 +95,8 @@ def create_test_db_with_reuse(self, verbosity=1, autoclobber=False,
     This method is a monkey patched version of create_test_db that
     will not actually create a new database, but just reuse the
     existing.
+
+    This is only used with Django < 1.8.
     """
     test_database_name = self._get_test_db_name()
     self.connection.settings_dict['NAME'] = test_database_name

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -188,8 +188,8 @@ class TestrunnerVerbosity:
             "*PASSED*Destroying test database for alias 'default' ('*')...*"])
 
     def test_more_verbose_with_vv_and_reusedb(self, testdir):
-        """More verbose output with '-v -v', and --reuse-db."""
-        result = testdir.runpytest_subprocess('-s', '-v', '-v', '--reuse-db')
+        """More verbose output with '-v -v', and --create-db."""
+        result = testdir.runpytest_subprocess('-s', '-v', '-v', '--create-db')
         result.stdout.fnmatch_lines([
             "tpkg/test_the_test.py:*Creating test database for alias*",
             "*PASSED*"])


### PR DESCRIPTION
Django 1.8 supports `--keepdb` [1], and it makes sense to make use of
it.  This should probably handle migrations in the context of
`transactional_db` better, i.e. by re-applying migrations with a flushed
DB.

1: https://docs.djangoproject.com/en/1.8/ref/django-admin/#django-admin-option---keepdb