### PR TITLE
Keep the existing PYTHONPATH in tox

### DIFF
--- a/generate_configurations.py
+++ b/generate_configurations.py
@@ -49,7 +49,7 @@ TOX_TESTENV_TEMPLATE = dedent("""
     deps =
     %(deps)s
     setenv =
-         PYTHONPATH = {toxinidir}
+         PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
          UID = %(uid)s
     """)
 

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 9
 
 
@@ -112,7 +112,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 10
 
 
@@ -127,7 +127,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 11
 
 
@@ -142,7 +142,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 12
 
 
@@ -157,7 +157,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 13
 
 
@@ -172,7 +172,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 14
 
 
@@ -187,7 +187,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 15
 
 
@@ -202,7 +202,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 16
 
 
@@ -217,7 +217,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 17
 
 
@@ -232,7 +232,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 18
 
 
@@ -247,7 +247,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 19
 
 
@@ -262,7 +262,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 20
 
 
@@ -277,7 +277,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 21
 
 
@@ -292,7 +292,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 22
 
 
@@ -307,7 +307,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 23
 
 
@@ -322,7 +322,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 24
 
 
@@ -337,7 +337,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 25
 
 
@@ -352,7 +352,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 26
 
 
@@ -367,7 +367,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 27
 
 
@@ -382,7 +382,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 28
 
 
@@ -397,7 +397,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 29
 
 
@@ -412,7 +412,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 30
 
 
@@ -427,7 +427,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 31
 
 
@@ -442,7 +442,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 32
 
 
@@ -457,7 +457,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 33
 
 
@@ -472,7 +472,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 34
 
 
@@ -487,7 +487,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 35
 
 
@@ -502,7 +502,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 36
 
 
@@ -516,7 +516,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 37
 
 
@@ -530,7 +530,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 38
 
 
@@ -544,7 +544,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 39
 
 
@@ -558,7 +558,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 40
 
 
@@ -572,7 +572,7 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 41
 
 
@@ -586,7 +586,7 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 42
 
 
@@ -600,7 +600,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 43
 
 
@@ -614,7 +614,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 44
 
 
@@ -628,7 +628,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 45
 
 
@@ -642,7 +642,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 46
 
 
@@ -656,7 +656,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 47
 
 
@@ -670,7 +670,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 48
 
 
@@ -684,7 +684,7 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 49
 
 
@@ -698,7 +698,7 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 50
 
 
@@ -712,7 +712,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 51
 
 
@@ -726,7 +726,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 52
 
 
@@ -743,7 +743,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 53
 
 
@@ -760,7 +760,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 54
 
 
@@ -777,7 +777,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 55
 
 
@@ -792,7 +792,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 56
 
 
@@ -807,7 +807,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 57
 
 
@@ -824,7 +824,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 58
 
 
@@ -841,7 +841,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 59
 
 
@@ -858,7 +858,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 60
 
 
@@ -873,7 +873,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 61
 
 
@@ -888,7 +888,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 62
 
 
@@ -905,7 +905,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 63
 
 
@@ -922,7 +922,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 64
 
 
@@ -939,7 +939,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 65
 
 
@@ -954,7 +954,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 66
 
 
@@ -969,7 +969,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 67
 
 
@@ -986,7 +986,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 68
 
 
@@ -1003,7 +1003,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 69
 
 
@@ -1020,7 +1020,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 70
 
 
@@ -1035,7 +1035,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 71
 
 
@@ -1050,7 +1050,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 72
 
 
@@ -1067,7 +1067,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 73
 
 
@@ -1084,7 +1084,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 74
 
 
@@ -1101,7 +1101,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 75
 
 
@@ -1116,7 +1116,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 76
 
 
@@ -1131,7 +1131,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 77
 
 
@@ -1148,7 +1148,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 78
 
 
@@ -1165,7 +1165,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 79
 
 
@@ -1182,7 +1182,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 80
 
 
@@ -1197,7 +1197,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 81
 
 
@@ -1212,7 +1212,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 82
 
 
@@ -1229,7 +1229,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 83
 
 
@@ -1246,7 +1246,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 84
 
 
@@ -1263,7 +1263,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 85
 
 
@@ -1278,7 +1278,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 86
 
 
@@ -1293,7 +1293,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 87
 
 
@@ -1310,7 +1310,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 88
 
 
@@ -1327,7 +1327,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 89
 
 
@@ -1344,7 +1344,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 90
 
 
@@ -1359,7 +1359,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 91
 
 
@@ -1374,7 +1374,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 92
 
 
@@ -1391,7 +1391,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 93
 
 
@@ -1408,7 +1408,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 94
 
 
@@ -1425,7 +1425,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 95
 
 
@@ -1440,7 +1440,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 96
 
 
@@ -1455,7 +1455,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 97
 
 
@@ -1472,7 +1472,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 98
 
 
@@ -1489,7 +1489,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 99
 
 
@@ -1506,7 +1506,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 100
 
 
@@ -1521,7 +1521,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 101
 
 
@@ -1536,7 +1536,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 102
 
 
@@ -1553,7 +1553,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 103
 
 
@@ -1570,7 +1570,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 104
 
 
@@ -1587,7 +1587,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 105
 
 
@@ -1602,7 +1602,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 106
 
 
@@ -1617,7 +1617,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 107
 
 
@@ -1634,7 +1634,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 108
 
 
@@ -1651,7 +1651,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 109
 
 
@@ -1668,7 +1668,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 110
 
 
@@ -1683,7 +1683,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 111
 
 
@@ -1698,7 +1698,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 112
 
 
@@ -1715,7 +1715,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 113
 
 
@@ -1732,7 +1732,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 114
 
 
@@ -1749,7 +1749,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 115
 
 
@@ -1764,7 +1764,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 116
 
 
@@ -1779,7 +1779,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 117
 
 
@@ -1796,7 +1796,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 118
 
 
@@ -1813,7 +1813,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 119
 
 
@@ -1830,7 +1830,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 120
 
 
@@ -1845,7 +1845,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 121
 
 
@@ -1860,7 +1860,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 122
 
 
@@ -1877,7 +1877,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 123
 
 
@@ -1894,7 +1894,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 124
 
 
@@ -1911,7 +1911,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 125
 
 
@@ -1926,7 +1926,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 126
 
 
@@ -1941,7 +1941,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 127
 
 
@@ -1958,7 +1958,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 128
 
 
@@ -1975,7 +1975,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 129
 
 
@@ -1992,7 +1992,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 130
 
 
@@ -2007,7 +2007,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 131
 
 
@@ -2022,7 +2022,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 132
 
 
@@ -2039,7 +2039,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 133
 
 
@@ -2056,7 +2056,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 134
 
 
@@ -2073,7 +2073,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 135
 
 
@@ -2088,7 +2088,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 136
 
 
@@ -2103,7 +2103,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 137
 
 
@@ -2120,7 +2120,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 138
 
 
@@ -2137,7 +2137,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 139
 
 
@@ -2154,7 +2154,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 140
 
 
@@ -2169,7 +2169,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 141
 
 
@@ -2184,7 +2184,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 142
 
 
@@ -2201,7 +2201,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 143
 
 
@@ -2218,7 +2218,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 144
 
 
@@ -2235,7 +2235,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 145
 
 
@@ -2250,7 +2250,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 146
 
 
@@ -2265,7 +2265,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 147
 
 
@@ -2282,7 +2282,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 148
 
 
@@ -2299,7 +2299,7 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 149
 
 
@@ -2316,7 +2316,7 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 150
 
 
@@ -2331,7 +2331,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 151
 
 
@@ -2346,7 +2346,7 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 152
 
 
@@ -2362,7 +2362,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 153
 
 
@@ -2376,7 +2376,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 154
 
 
@@ -2390,7 +2390,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 155
 
 
@@ -2406,7 +2406,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 156
 
 
@@ -2420,7 +2420,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 157
 
 
@@ -2434,7 +2434,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 158
 
 
@@ -2450,7 +2450,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 159
 
 
@@ -2464,7 +2464,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 160
 
 
@@ -2478,7 +2478,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 161
 
 
@@ -2494,7 +2494,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 162
 
 
@@ -2508,7 +2508,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 163
 
 
@@ -2522,7 +2522,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 164
 
 
@@ -2538,7 +2538,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 165
 
 
@@ -2552,7 +2552,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 166
 
 
@@ -2566,7 +2566,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 167
 
 
@@ -2582,7 +2582,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 168
 
 
@@ -2596,7 +2596,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 169
 
 
@@ -2610,7 +2610,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 170
 
 
@@ -2626,7 +2626,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 171
 
 
@@ -2640,7 +2640,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 172
 
 
@@ -2654,7 +2654,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 173
 
 
@@ -2670,7 +2670,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 174
 
 
@@ -2684,7 +2684,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 175
 
 
@@ -2698,7 +2698,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 176
 
 
@@ -2714,7 +2714,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 177
 
 
@@ -2728,7 +2728,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 178
 
 
@@ -2742,7 +2742,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 179
 
 
@@ -2758,7 +2758,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 180
 
 
@@ -2772,7 +2772,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 181
 
 
@@ -2786,7 +2786,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 182
 
 
@@ -2802,7 +2802,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 183
 
 
@@ -2816,7 +2816,7 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 184
 
 
@@ -2830,7 +2830,7 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 185
 
 
@@ -2846,7 +2846,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 186
 
 
@@ -2860,7 +2860,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 187
 
 
@@ -2874,7 +2874,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 188
 
 
@@ -2890,7 +2890,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 189
 
 
@@ -2904,7 +2904,7 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 190
 
 
@@ -2918,7 +2918,7 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 191
 
 
@@ -2934,7 +2934,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 192
 
 
@@ -2948,7 +2948,7 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 193
 
 
@@ -2962,7 +2962,7 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 194
 
 
@@ -2978,7 +2978,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 195
 
 
@@ -2992,7 +2992,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 196
 
 
@@ -3006,7 +3006,7 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 197
 
 
@@ -3022,7 +3022,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 198
 
 
@@ -3036,7 +3036,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 199
 
 
@@ -3050,7 +3050,7 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 200
 
 
@@ -3066,7 +3066,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 201
 
 
@@ -3080,7 +3080,7 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 202
 
 
@@ -3094,7 +3094,7 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 203
 
 
@@ -3110,7 +3110,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 204
 
 
@@ -3124,7 +3124,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 205
 
 
@@ -3138,7 +3138,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 206
 
 
@@ -3154,7 +3154,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 207
 
 
@@ -3168,7 +3168,7 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 208
 
 
@@ -3182,7 +3182,7 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 209
 
 
@@ -3198,7 +3198,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 210
 
 
@@ -3212,7 +3212,7 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 211
 
 
@@ -3226,7 +3226,7 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 212
 
 
@@ -3242,7 +3242,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 213
 
 
@@ -3256,7 +3256,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 214
 
 
@@ -3270,7 +3270,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 215
 
 
@@ -3286,7 +3286,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 216
 
 
@@ -3300,7 +3300,7 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 217
 
 
@@ -3314,7 +3314,7 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 218
 
 
@@ -3330,7 +3330,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 219
 
 
@@ -3344,7 +3344,7 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 220
 
 
@@ -3358,7 +3358,7 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 221
 
 
@@ -3374,7 +3374,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 222
 
 
@@ -3388,7 +3388,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 223
 
 
@@ -3402,7 +3402,7 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 224
 
 
@@ -3418,7 +3418,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 225
 
 
@@ -3432,7 +3432,7 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 226
 
 
@@ -3446,7 +3446,7 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 227
 
 
@@ -3462,7 +3462,7 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 228
 
 
@@ -3476,7 +3476,7 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 229
 
 
@@ -3490,5 +3490,5 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 230


### PR DESCRIPTION
Without this the tests could not be run on systems that already use PYTHONPATH (like NixOS).