### PR TITLE
Do not set PYTHONPATH explicitly

### DIFF
--- a/generate_configurations.py
+++ b/generate_configurations.py
@@ -49,7 +49,6 @@ TOX_TESTENV_TEMPLATE = dedent("""
     deps =
     %(deps)s
     setenv =
-         PYTHONPATH = {toxinidir}
          UID = %(uid)s
     """)
 

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 9
 
 
@@ -112,7 +111,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 10
 
 
@@ -127,7 +125,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 11
 
 
@@ -142,7 +139,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 12
 
 
@@ -157,7 +153,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 13
 
 
@@ -172,7 +167,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 14
 
 
@@ -187,7 +181,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 15
 
 
@@ -202,7 +195,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 16
 
 
@@ -217,7 +209,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 17
 
 
@@ -232,7 +223,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 18
 
 
@@ -247,7 +237,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 19
 
 
@@ -262,7 +251,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 20
 
 
@@ -277,7 +265,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 21
 
 
@@ -292,7 +279,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 22
 
 
@@ -307,7 +293,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 23
 
 
@@ -322,7 +307,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 24
 
 
@@ -337,7 +321,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 25
 
 
@@ -352,7 +335,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 26
 
 
@@ -367,7 +349,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 27
 
 
@@ -382,7 +363,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 28
 
 
@@ -397,7 +377,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 29
 
 
@@ -412,7 +391,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 30
 
 
@@ -427,7 +405,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 31
 
 
@@ -442,7 +419,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 32
 
 
@@ -457,7 +433,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 33
 
 
@@ -472,7 +447,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 34
 
 
@@ -487,7 +461,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 35
 
 
@@ -502,7 +475,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 36
 
 
@@ -516,7 +488,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 37
 
 
@@ -530,7 +501,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 38
 
 
@@ -544,7 +514,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 39
 
 
@@ -558,7 +527,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 40
 
 
@@ -572,7 +540,6 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 41
 
 
@@ -586,7 +553,6 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 42
 
 
@@ -600,7 +566,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 43
 
 
@@ -614,7 +579,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 44
 
 
@@ -628,7 +592,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 45
 
 
@@ -642,7 +605,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 46
 
 
@@ -656,7 +618,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 47
 
 
@@ -670,7 +631,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 48
 
 
@@ -684,7 +644,6 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 49
 
 
@@ -698,7 +657,6 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 50
 
 
@@ -712,7 +670,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 51
 
 
@@ -726,7 +683,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 52
 
 
@@ -743,7 +699,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 53
 
 
@@ -760,7 +715,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 54
 
 
@@ -777,7 +731,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 55
 
 
@@ -792,7 +745,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 56
 
 
@@ -807,7 +759,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 57
 
 
@@ -824,7 +775,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 58
 
 
@@ -841,7 +791,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 59
 
 
@@ -858,7 +807,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 60
 
 
@@ -873,7 +821,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 61
 
 
@@ -888,7 +835,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 62
 
 
@@ -905,7 +851,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 63
 
 
@@ -922,7 +867,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 64
 
 
@@ -939,7 +883,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 65
 
 
@@ -954,7 +897,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 66
 
 
@@ -969,7 +911,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 67
 
 
@@ -986,7 +927,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 68
 
 
@@ -1003,7 +943,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 69
 
 
@@ -1020,7 +959,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 70
 
 
@@ -1035,7 +973,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 71
 
 
@@ -1050,7 +987,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 72
 
 
@@ -1067,7 +1003,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 73
 
 
@@ -1084,7 +1019,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 74
 
 
@@ -1101,7 +1035,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 75
 
 
@@ -1116,7 +1049,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 76
 
 
@@ -1131,7 +1063,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 77
 
 
@@ -1148,7 +1079,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 78
 
 
@@ -1165,7 +1095,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 79
 
 
@@ -1182,7 +1111,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 80
 
 
@@ -1197,7 +1125,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 81
 
 
@@ -1212,7 +1139,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 82
 
 
@@ -1229,7 +1155,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 83
 
 
@@ -1246,7 +1171,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 84
 
 
@@ -1263,7 +1187,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 85
 
 
@@ -1278,7 +1201,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 86
 
 
@@ -1293,7 +1215,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 87
 
 
@@ -1310,7 +1231,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 88
 
 
@@ -1327,7 +1247,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 89
 
 
@@ -1344,7 +1263,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 90
 
 
@@ -1359,7 +1277,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 91
 
 
@@ -1374,7 +1291,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 92
 
 
@@ -1391,7 +1307,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 93
 
 
@@ -1408,7 +1323,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 94
 
 
@@ -1425,7 +1339,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 95
 
 
@@ -1440,7 +1353,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 96
 
 
@@ -1455,7 +1367,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 97
 
 
@@ -1472,7 +1383,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 98
 
 
@@ -1489,7 +1399,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 99
 
 
@@ -1506,7 +1415,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 100
 
 
@@ -1521,7 +1429,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 101
 
 
@@ -1536,7 +1443,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 102
 
 
@@ -1553,7 +1459,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 103
 
 
@@ -1570,7 +1475,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 104
 
 
@@ -1587,7 +1491,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 105
 
 
@@ -1602,7 +1505,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 106
 
 
@@ -1617,7 +1519,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 107
 
 
@@ -1634,7 +1535,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 108
 
 
@@ -1651,7 +1551,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 109
 
 
@@ -1668,7 +1567,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 110
 
 
@@ -1683,7 +1581,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 111
 
 
@@ -1698,7 +1595,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 112
 
 
@@ -1715,7 +1611,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 113
 
 
@@ -1732,7 +1627,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 114
 
 
@@ -1749,7 +1643,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 115
 
 
@@ -1764,7 +1657,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 116
 
 
@@ -1779,7 +1671,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 117
 
 
@@ -1796,7 +1687,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 118
 
 
@@ -1813,7 +1703,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 119
 
 
@@ -1830,7 +1719,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 120
 
 
@@ -1845,7 +1733,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 121
 
 
@@ -1860,7 +1747,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 122
 
 
@@ -1877,7 +1763,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 123
 
 
@@ -1894,7 +1779,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 124
 
 
@@ -1911,7 +1795,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 125
 
 
@@ -1926,7 +1809,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 126
 
 
@@ -1941,7 +1823,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 127
 
 
@@ -1958,7 +1839,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 128
 
 
@@ -1975,7 +1855,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 129
 
 
@@ -1992,7 +1871,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 130
 
 
@@ -2007,7 +1885,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 131
 
 
@@ -2022,7 +1899,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 132
 
 
@@ -2039,7 +1915,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 133
 
 
@@ -2056,7 +1931,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 134
 
 
@@ -2073,7 +1947,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 135
 
 
@@ -2088,7 +1961,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 136
 
 
@@ -2103,7 +1975,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 137
 
 
@@ -2120,7 +1991,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 138
 
 
@@ -2137,7 +2007,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 139
 
 
@@ -2154,7 +2023,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 140
 
 
@@ -2169,7 +2037,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 141
 
 
@@ -2184,7 +2051,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 142
 
 
@@ -2201,7 +2067,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 143
 
 
@@ -2218,7 +2083,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 144
 
 
@@ -2235,7 +2099,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 145
 
 
@@ -2250,7 +2113,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 146
 
 
@@ -2265,7 +2127,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 147
 
 
@@ -2282,7 +2143,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 148
 
 
@@ -2299,7 +2159,6 @@ deps =
     south==1.0.2
     mysql-python==1.2.5
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 149
 
 
@@ -2316,7 +2175,6 @@ deps =
     south==1.0.2
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 150
 
 
@@ -2331,7 +2189,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 151
 
 
@@ -2346,7 +2203,6 @@ deps =
     django-configurations==0.8
     south==1.0.2
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 152
 
 
@@ -2362,7 +2218,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 153
 
 
@@ -2376,7 +2231,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 154
 
 
@@ -2390,7 +2244,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 155
 
 
@@ -2406,7 +2259,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 156
 
 
@@ -2420,7 +2272,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 157
 
 
@@ -2434,7 +2285,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 158
 
 
@@ -2450,7 +2300,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 159
 
 
@@ -2464,7 +2313,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 160
 
 
@@ -2478,7 +2326,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 161
 
 
@@ -2494,7 +2341,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 162
 
 
@@ -2508,7 +2354,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 163
 
 
@@ -2522,7 +2367,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 164
 
 
@@ -2538,7 +2382,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 165
 
 
@@ -2552,7 +2395,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 166
 
 
@@ -2566,7 +2408,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 167
 
 
@@ -2582,7 +2423,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 168
 
 
@@ -2596,7 +2436,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 169
 
 
@@ -2610,7 +2449,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 170
 
 
@@ -2626,7 +2464,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 171
 
 
@@ -2640,7 +2477,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 172
 
 
@@ -2654,7 +2490,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 173
 
 
@@ -2670,7 +2505,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 174
 
 
@@ -2684,7 +2518,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 175
 
 
@@ -2698,7 +2531,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 176
 
 
@@ -2714,7 +2546,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 177
 
 
@@ -2728,7 +2559,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 178
 
 
@@ -2742,7 +2572,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 179
 
 
@@ -2758,7 +2587,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 180
 
 
@@ -2772,7 +2600,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 181
 
 
@@ -2786,7 +2613,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 182
 
 
@@ -2802,7 +2628,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 183
 
 
@@ -2816,7 +2641,6 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 184
 
 
@@ -2830,7 +2654,6 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 185
 
 
@@ -2846,7 +2669,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 186
 
 
@@ -2860,7 +2682,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 187
 
 
@@ -2874,7 +2695,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 188
 
 
@@ -2890,7 +2710,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 189
 
 
@@ -2904,7 +2723,6 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 190
 
 
@@ -2918,7 +2736,6 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 191
 
 
@@ -2934,7 +2751,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 192
 
 
@@ -2948,7 +2764,6 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 193
 
 
@@ -2962,7 +2777,6 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 194
 
 
@@ -2978,7 +2792,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 195
 
 
@@ -2992,7 +2805,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 196
 
 
@@ -3006,7 +2818,6 @@ deps =
     Django>=1.5,<1.6
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 197
 
 
@@ -3022,7 +2833,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 198
 
 
@@ -3036,7 +2846,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 199
 
 
@@ -3050,7 +2859,6 @@ deps =
     Django>=1.6,<1.7
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 200
 
 
@@ -3066,7 +2874,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 201
 
 
@@ -3080,7 +2887,6 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 202
 
 
@@ -3094,7 +2900,6 @@ deps =
     Django>=1.7,<1.8
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 203
 
 
@@ -3110,7 +2915,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 204
 
 
@@ -3124,7 +2928,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 205
 
 
@@ -3138,7 +2941,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 206
 
 
@@ -3154,7 +2956,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 207
 
 
@@ -3168,7 +2969,6 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 208
 
 
@@ -3182,7 +2982,6 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 209
 
 
@@ -3198,7 +2997,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 210
 
 
@@ -3212,7 +3010,6 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 211
 
 
@@ -3226,7 +3023,6 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 212
 
 
@@ -3242,7 +3038,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 213
 
 
@@ -3256,7 +3051,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 214
 
 
@@ -3270,7 +3064,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 215
 
 
@@ -3286,7 +3079,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 216
 
 
@@ -3300,7 +3092,6 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 217
 
 
@@ -3314,7 +3105,6 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 218
 
 
@@ -3330,7 +3120,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 219
 
 
@@ -3344,7 +3133,6 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 220
 
 
@@ -3358,7 +3146,6 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 221
 
 
@@ -3374,7 +3161,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 222
 
 
@@ -3388,7 +3174,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 223
 
 
@@ -3402,7 +3187,6 @@ deps =
     Django>=1.8,<1.9
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 224
 
 
@@ -3418,7 +3202,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 225
 
 
@@ -3432,7 +3215,6 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 226
 
 
@@ -3446,7 +3228,6 @@ deps =
     Django==1.9a1
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 227
 
 
@@ -3462,7 +3243,6 @@ deps =
     django-configurations==0.8
     psycopg2==2.6.1
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 228
 
 
@@ -3476,7 +3256,6 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 229
 
 
@@ -3490,5 +3269,4 @@ deps =
     https://github.com/django/django/archive/master.tar.gz
     django-configurations==0.8
 setenv =
-     PYTHONPATH = {toxinidir}
      UID = 230


### PR DESCRIPTION
tox will prepend the cwd automatically [1].

1: https://bitbucket.org/hpk42/tox/src/3ed5dc353a99acf57859a2dd265b5c2e973480e3/tox/_pytestplugin.py?at=default&fileviewer=file-view-default#_pytestplugin.py-192:193

Ref: https://github.com/pytest-dev/pytest-django/pull/278#issuecomment-145352363

To fix #278, maybe `passenv PYTHONPATH` would be required.