### PR TITLE
Fix for #280.

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -251,7 +251,13 @@ def pytest_configure():
 
 
 def _method_is_defined_at_leaf(cls, method_name):
-    return getattr(cls.__base__, method_name).__func__ is not getattr(cls, method_name).__func__
+    super_method = None
+
+    for base_cls in cls.__bases__:
+        if hasattr(base_cls, method_name):
+            super_method = getattr(base_cls, method_name)
+
+    return getattr(cls, method_name).__func__ is not super_method.__func__
 
 
 _disabled_classmethods = {}

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -257,6 +257,8 @@ def _method_is_defined_at_leaf(cls, method_name):
         if hasattr(base_cls, method_name):
             super_method = getattr(base_cls, method_name)
 
+    assert super_method is not None, '%s could not be found in base class' % method_name
+
     return getattr(cls, method_name).__func__ is not super_method.__func__
 
 

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -124,7 +124,13 @@ class TestUnittestMethods:
             from django.test import TestCase
             from .app.models import Item
 
-            class TestA(TestCase):
+            # Using a mixin is a regression test, see #280 for more details:
+            # https://github.com/pytest-dev/pytest-django/issues/280
+
+            class SomeMixin(object):
+                pass
+
+            class TestA(SomeMixin, TestCase):
                 expected_state = ['A']
                 state = []
 


### PR DESCRIPTION
The previous fix did not properly check the full MRO chain when looking
for the super method, which then failed when used with mixins that does
not define setUpClass/tearDownClass.

This commit fixes issue #280.