### PR TITLE
Add '--retry-db' flag to let the test runner retry database creation

### DIFF
--- a/pytest_django/db_retry.py
+++ b/pytest_django/db_retry.py
@@ -1,0 +1,20 @@
+"""Functions to aid in retrying failed attempts to setup the database."""
+
+import time
+from functools import wraps
+
+
+def wrap_creation_for_db_retry(setup_db_func, max_retries=5, timeout_sec=1):
+    from django.db import OperationalError
+
+    @wraps(setup_db_func)
+    def retry_it(*args, **kwargs):
+        for i in range(max_retries):
+            try:
+                return setup_db_func(*args, **kwargs)
+            except OperationalError:
+                if i == max_retries:
+                    raise
+                time.sleep(timeout_sec)
+
+    return retry_it

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 from . import live_server_helper
-
+from .db_retry import wrap_creation_for_db_retry
 from .django_compat import is_django_unittest
 
 from .lazy_django import get_django_version, skip_if_no_django
@@ -88,6 +88,9 @@ def django_db_setup(
 
             with django_db_blocker.unblock():
                 monkey_patch_creation_for_db_reuse()
+
+    if request.config.getvalue('retry_db'):
+        setup_databases = wrap_creation_for_db_retry(setup_databases)
 
     with django_db_blocker.unblock():
         db_cfg = setup_databases(

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -53,6 +53,10 @@ def pytest_addoption(parser):
                      action='store_true', dest='create_db', default=False,
                      help='Re-create the database, even if it exists. This '
                           'option can be used to override --reuse-db.')
+    group._addoption('--retry-db',
+                     action='store_true', dest='retry_db', default=False,
+                     help='Retry database creation if it fails to connect to '
+                          'the database')
     group._addoption('--ds',
                      action='store', type='string', dest='ds', default=None,
                      help='Set DJANGO_SETTINGS_MODULE.')


### PR DESCRIPTION
In some testing situations, a database may be dynamically created at the
time the tests are run. (i.e. when using Docker). In these situations,
if the database server has not completed initialization prior to the
test runner beginning setup_databases(), the test run will fail. This PR
prevents that issue by adding a new --retry-db flag that catches
exceptions and retries database creation.

I didn't add a test for this particular flag yet. I wanted to bounce it off you and get some thoughts on the best way to simulate database failure in a test might be.
