### PR TITLE
Add `--migrations` option to negate `--nomigrations`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,9 +3,17 @@ Changelog
 
 NEXT
 ----
+Bug fixes
+^^^^^^^^^
+
 * Fix error when Django happens to be imported before pytest-django runs.
   Thanks to Will Harris for `the bug report
   <https://github.com/pytest-dev/pytest-django/issues/289>`_.
+
+Features
+^^^^^^^^
+* Added a new option `--migrations` to negate a default usage of
+  `--nomigrations`.
 
 2.9.1
 -----

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -128,3 +128,5 @@ Using ``--nomigrations`` will `disable Django 1.7+ migrations <https://gist.gith
 and create the database inspecting all app models (the default behavior of
 Django until version 1.6). It may be faster when there are several migrations
 to run in the database setup.
+You can use ``--migrations`` to force running migrations in case
+``--nomigrations`` is used, e.g. in ``setup.cfg``.

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -51,9 +51,12 @@ def pytest_addoption(parser):
     group._addoption('--dc',
                      action='store', type='string', dest='dc', default=None,
                      help='Set DJANGO_CONFIGURATION.')
-    group._addoption('--nomigrations',
+    group._addoption('--nomigrations', '--no-migrations',
                      action='store_true', dest='nomigrations', default=False,
-                     help='Disable Django 1.7 migrations on test setup')
+                     help='Disable Django 1.7+ migrations on test setup')
+    group._addoption('--migrations',
+                     action='store_false', dest='nomigrations', default=False,
+                     help='Enable Django 1.7+ migrations on test setup')
     parser.addini(CONFIGURATION_ENV,
                   'django-configurations class to use by pytest-django.')
     group._addoption('--liveserver', default=None,

--- a/tests/test_db_setup.py
+++ b/tests/test_db_setup.py
@@ -518,3 +518,8 @@ class TestNativeMigrations(object):
         result = testdir.runpytest_subprocess('--tb=short', '-v', '-s')
         assert result.ret == 0
         result.stdout.fnmatch_lines(['*mark_migrations_run*'])
+
+        result = testdir.runpytest_subprocess('--no-migrations', '--migrations',
+                                              '--tb=short', '-v', '-s')
+        assert result.ret == 0
+        result.stdout.fnmatch_lines(['*mark_migrations_run*'])


### PR DESCRIPTION
This also adds `--no-migrations` as an alias.

Fixes https://github.com/pytest-dev/pytest-django/issues/311.