### PR TITLE
tests: update versions, drop support for Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,43 +4,42 @@ language: python
 python:
   - "3.5"
 env:
-  - TESTENV=pypy-2.8.1-master-sqlite_file
-  - TESTENV=pypy3-2.8.1-1.8-sqlite_file
-  - TESTENV=python2.6-2.8.1-1.6-sqlite_file
-  - TESTENV=python2.7-2.8.1-1.4-sqlite_file
-  - TESTENV=python2.7-2.8.1-1.5-sqlite_file
-  - TESTENV=python2.7-2.8.1-1.6-sqlite_file
-  - TESTENV=python2.7-2.8.1-1.7-sqlite_file
-  - TESTENV=python2.7-2.8.1-1.8-sqlite_file
-  - TESTENV=python2.7-2.8.1-1.9-sqlite_file
-  - TESTENV=python2.7-2.8.1-master-mysql_innodb
-  - TESTENV=python2.7-2.8.1-master-mysql_myisam
-  - TESTENV=python2.7-2.8.1-master-sqlite_file
-  - TESTENV=python3.2-2.8.1-1.6-sqlite_file
-  - TESTENV=python3.3-2.8.1-1.6-sqlite_file
-  - TESTENV=python3.4-2.8.1-1.5-sqlite_file
-  - TESTENV=python3.4-2.8.1-1.6-sqlite_file
-  - TESTENV=python3.4-2.8.1-1.7-sqlite_file
-  - TESTENV=python3.4-2.8.1-1.8-sqlite_file
-  - TESTENV=python3.4-2.8.1-1.9-sqlite_file
-  - TESTENV=python3.4-2.8.1-master-sqlite_file
+  - TESTENV=pypy-2.8.7-master-sqlite_file
+  - TESTENV=pypy3-2.8.7-1.8-sqlite_file
+  - TESTENV=python2.6-2.8.7-1.6-sqlite_file
+  - TESTENV=python2.7-2.8.7-1.4-sqlite_file
+  - TESTENV=python2.7-2.8.7-1.5-sqlite_file
+  - TESTENV=python2.7-2.8.7-1.6-sqlite_file
+  - TESTENV=python2.7-2.8.7-1.7-sqlite_file
+  - TESTENV=python2.7-2.8.7-1.8-sqlite_file
+  - TESTENV=python2.7-2.8.7-1.9-sqlite_file
+  - TESTENV=python2.7-2.8.7-master-mysql_innodb
+  - TESTENV=python2.7-2.8.7-master-mysql_myisam
+  - TESTENV=python2.7-2.8.7-master-sqlite_file
+  - TESTENV=python3.3-2.8.7-1.6-sqlite_file
+  - TESTENV=python3.4-2.8.7-1.5-sqlite_file
+  - TESTENV=python3.4-2.8.7-1.6-sqlite_file
+  - TESTENV=python3.4-2.8.7-1.7-sqlite_file
+  - TESTENV=python3.4-2.8.7-1.8-sqlite_file
+  - TESTENV=python3.4-2.8.7-1.9-sqlite_file
+  - TESTENV=python3.4-2.8.7-master-sqlite_file
   - TESTENV=python3.5-2.7.3-master-sqlite_file
-  - TESTENV=python3.5-2.8.1-master-postgres
-  - TESTENV=python3.5-2.8.1-master-sqlite
-  - TESTENV=python3.5-2.8.1-master-sqlite_file
+  - TESTENV=python3.5-2.8.7-master-postgres
+  - TESTENV=python3.5-2.8.7-master-sqlite
+  - TESTENV=python3.5-2.8.7-master-sqlite_file
   - TESTENV=checkqa-python2.7
   - TESTENV=checkqa-python3.4
 matrix:
   allow_failures:
-    - env: TESTENV=pypy-2.8.1-master-sqlite_file
-    - env: TESTENV=python2.7-2.8.1-master-mysql_innodb
-    - env: TESTENV=python2.7-2.8.1-master-mysql_myisam
-    - env: TESTENV=python2.7-2.8.1-master-sqlite_file
-    - env: TESTENV=python3.4-2.8.1-master-sqlite_file
+    - env: TESTENV=pypy-2.8.7-master-sqlite_file
+    - env: TESTENV=python2.7-2.8.7-master-mysql_innodb
+    - env: TESTENV=python2.7-2.8.7-master-mysql_myisam
+    - env: TESTENV=python2.7-2.8.7-master-sqlite_file
+    - env: TESTENV=python3.4-2.8.7-master-sqlite_file
     - env: TESTENV=python3.5-2.7.3-master-sqlite_file
-    - env: TESTENV=python3.5-2.8.1-master-postgres
-    - env: TESTENV=python3.5-2.8.1-master-sqlite
-    - env: TESTENV=python3.5-2.8.1-master-sqlite_file
+    - env: TESTENV=python3.5-2.8.7-master-postgres
+    - env: TESTENV=python3.5-2.8.7-master-sqlite
+    - env: TESTENV=python3.5-2.8.7-master-sqlite_file
 install:
   # Create pip wrapper script, using travis_retry (a function) and
   # inject it into tox.ini.
@@ -55,5 +54,5 @@ install:
   - sed -i.bak 's/whitelist_externals =/\0\n    travis_retry_pip/' tox.ini
   - diff tox.ini tox.ini.bak && return 1 || true
 
-  - pip install tox==2.1.1
+  - pip install tox==2.3.1
 script: tox -e $TESTENV

--- a/generate_configurations.py
+++ b/generate_configurations.py
@@ -25,9 +25,9 @@ class TestEnv(TestEnvBase):
 # Python to run tox.
 RUN_PYTHON = '3.5'
 PYTHON_MAIN_VERSIONS = ['python2.7', 'python3.4']
-PYTHON_VERSIONS = ['python2.6', 'python2.7', 'python3.2', 'python3.3',
+PYTHON_VERSIONS = ['python2.6', 'python2.7', 'python3.3',
                    'python3.4', 'python3.5', 'pypy', 'pypy3']
-PYTEST_VERSIONS = ['2.7.3', '2.8.1']
+PYTEST_VERSIONS = ['2.7.3', '2.8.7']
 DJANGO_VERSIONS = ['1.4', '1.5', '1.6', '1.7', '1.8', '1.9', 'master']
 SETTINGS = ['sqlite', 'sqlite_file', 'mysql_myisam', 'mysql_innodb',
             'postgres']
@@ -74,7 +74,7 @@ def is_valid_env(env):
         return False
 
     # Django 1.9 dropped Python 3.2 and Python 3.3 support
-    if (env.python_version in ('python3.2', 'python3.3') and
+    if (env.python_version == 'python3.3' and
         env.django_version in ('1.7', '1.8', '1.9', 'master')):
         return False
 
@@ -91,9 +91,9 @@ def is_valid_env(env):
 
 def requirements(env):
     yield 'pytest==%s' % (env.pytest_version)
-    yield 'pytest-xdist==1.13.1'
+    yield 'pytest-xdist==1.14'
     yield DJANGO_REQUIREMENTS[env.django_version]
-    yield 'django-configurations==0.8'
+    yield 'django-configurations==1.0'
 
     if env.is_py2():
         yield 'south==1.0.2'
@@ -253,7 +253,7 @@ def make_travis_yml(envs):
           - sed -i.bak 's/whitelist_externals =/\\0\\n    travis_retry_pip/' tox.ini
           - diff tox.ini tox.ini.bak && return 1 || true
 
-          - pip install tox==2.1.1
+          - pip install tox==2.3.1
         script: tox -e $TESTENV
         """).strip("\n")
     testenvs = '\n'.join('  - TESTENV=%s' % testenv_name(env) for env in envs)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy-2.8.1-master-sqlite_file,pypy3-2.8.1-1.8-sqlite_file,python2.6-2.8.1-1.6-sqlite_file,python2.7-2.8.1-1.4-sqlite_file,python2.7-2.8.1-1.5-sqlite_file,python2.7-2.8.1-1.6-sqlite_file,python2.7-2.8.1-1.7-sqlite_file,python2.7-2.8.1-1.8-sqlite_file,python2.7-2.8.1-1.9-sqlite_file,python2.7-2.8.1-master-mysql_innodb,python2.7-2.8.1-master-mysql_myisam,python2.7-2.8.1-master-sqlite_file,python3.2-2.8.1-1.6-sqlite_file,python3.3-2.8.1-1.6-sqlite_file,python3.4-2.8.1-1.5-sqlite_file,python3.4-2.8.1-1.6-sqlite_file,python3.4-2.8.1-1.7-sqlite_file,python3.4-2.8.1-1.8-sqlite_file,python3.4-2.8.1-1.9-sqlite_file,python3.4-2.8.1-master-sqlite_file,python3.5-2.7.3-master-sqlite_file,python3.5-2.8.1-master-postgres,python3.5-2.8.1-master-sqlite,python3.5-2.8.1-master-sqlite_file,checkqa-python2.7,checkqa-python3.4
+envlist = pypy-2.8.7-master-sqlite_file,pypy3-2.8.7-1.8-sqlite_file,python2.6-2.8.7-1.6-sqlite_file,python2.7-2.8.7-1.4-sqlite_file,python2.7-2.8.7-1.5-sqlite_file,python2.7-2.8.7-1.6-sqlite_file,python2.7-2.8.7-1.7-sqlite_file,python2.7-2.8.7-1.8-sqlite_file,python2.7-2.8.7-1.9-sqlite_file,python2.7-2.8.7-master-mysql_innodb,python2.7-2.8.7-master-mysql_myisam,python2.7-2.8.7-master-sqlite_file,python3.3-2.8.7-1.6-sqlite_file,python3.4-2.8.7-1.5-sqlite_file,python3.4-2.8.7-1.6-sqlite_file,python3.4-2.8.7-1.7-sqlite_file,python3.4-2.8.7-1.8-sqlite_file,python3.4-2.8.7-1.9-sqlite_file,python3.4-2.8.7-master-sqlite_file,python3.5-2.7.3-master-sqlite_file,python3.5-2.8.7-master-postgres,python3.5-2.8.7-master-sqlite,python3.5-2.8.7-master-sqlite_file,checkqa-python2.7,checkqa-python3.4
 
 [testenv]
 whitelist_externals =
@@ -26,16 +26,6 @@ deps =
 setenv =
     UID = 2
 
-[testenv:checkqa-python3.2]
-commands =
-    flake8 --version
-    flake8 --show-source --statistics pytest_django tests
-basepython = python3.2
-deps =
-    flake8
-setenv =
-    UID = 3
-
 [testenv:checkqa-python3.3]
 commands =
     flake8 --version
@@ -44,7 +34,7 @@ basepython = python3.3
 deps =
     flake8
 setenv =
-    UID = 4
+    UID = 3
 
 [testenv:checkqa-python3.4]
 commands =
@@ -54,7 +44,7 @@ basepython = python3.4
 deps =
     flake8
 setenv =
-    UID = 5
+    UID = 4
 
 [testenv:checkqa-python3.5]
 commands =
@@ -64,7 +54,7 @@ basepython = python3.5
 deps =
     flake8
 setenv =
-    UID = 6
+    UID = 5
 
 [testenv:checkqa-pypy]
 commands =
@@ -74,7 +64,7 @@ basepython = pypy
 deps =
     flake8
 setenv =
-    UID = 7
+    UID = 6
 
 [testenv:checkqa-pypy3]
 commands =
@@ -84,7 +74,7 @@ basepython = pypy3
 deps =
     flake8
 setenv =
-    UID = 8
+    UID = 7
 
 [testenv:pypy-2.7.3-1.4-sqlite]
 commands =
@@ -92,13 +82,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 9
+     UID = 8
 
 
 [testenv:pypy-2.7.3-1.4-sqlite_file]
@@ -107,13 +97,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 10
+     UID = 9
 
 
 [testenv:pypy-2.7.3-1.5-sqlite]
@@ -122,13 +112,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 11
+     UID = 10
 
 
 [testenv:pypy-2.7.3-1.5-sqlite_file]
@@ -137,13 +127,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 12
+     UID = 11
 
 
 [testenv:pypy-2.7.3-1.6-sqlite]
@@ -152,13 +142,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 13
+     UID = 12
 
 
 [testenv:pypy-2.7.3-1.6-sqlite_file]
@@ -167,13 +157,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 14
+     UID = 13
 
 
 [testenv:pypy-2.7.3-1.7-sqlite]
@@ -182,13 +172,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 15
+     UID = 14
 
 
 [testenv:pypy-2.7.3-1.7-sqlite_file]
@@ -197,13 +187,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 16
+     UID = 15
 
 
 [testenv:pypy-2.7.3-1.8-sqlite]
@@ -212,13 +202,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 17
+     UID = 16
 
 
 [testenv:pypy-2.7.3-1.8-sqlite_file]
@@ -227,13 +217,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 18
+     UID = 17
 
 
 [testenv:pypy-2.7.3-1.9-sqlite]
@@ -242,13 +232,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 19
+     UID = 18
 
 
 [testenv:pypy-2.7.3-1.9-sqlite_file]
@@ -257,13 +247,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 20
+     UID = 19
 
 
 [testenv:pypy-2.7.3-master-sqlite]
@@ -272,13 +262,13 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 21
+     UID = 20
 
 
 [testenv:pypy-2.7.3-master-sqlite_file]
@@ -287,223 +277,223 @@ commands =
 basepython = pypy
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
+    south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 21
+
+
+[testenv:pypy-2.8.7-1.4-sqlite]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+basepython = pypy
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.4,<1.5
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 22
 
 
-[testenv:pypy-2.8.1-1.4-sqlite]
+[testenv:pypy-2.8.7-1.4-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 23
 
 
-[testenv:pypy-2.8.1-1.4-sqlite_file]
+[testenv:pypy-2.8.7-1.5-sqlite]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.4,<1.5
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.5,<1.6
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 24
 
 
-[testenv:pypy-2.8.1-1.5-sqlite]
+[testenv:pypy-2.8.7-1.5-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 25
 
 
-[testenv:pypy-2.8.1-1.5-sqlite_file]
+[testenv:pypy-2.8.7-1.6-sqlite]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.6,<1.7
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 26
 
 
-[testenv:pypy-2.8.1-1.6-sqlite]
+[testenv:pypy-2.8.7-1.6-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 27
 
 
-[testenv:pypy-2.8.1-1.6-sqlite_file]
+[testenv:pypy-2.8.7-1.7-sqlite]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.7,<1.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 28
 
 
-[testenv:pypy-2.8.1-1.7-sqlite]
+[testenv:pypy-2.8.7-1.7-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 29
 
 
-[testenv:pypy-2.8.1-1.7-sqlite_file]
+[testenv:pypy-2.8.7-1.8-sqlite]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.7,<1.8
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.8,<1.9
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 30
 
 
-[testenv:pypy-2.8.1-1.8-sqlite]
+[testenv:pypy-2.8.7-1.8-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 31
 
 
-[testenv:pypy-2.8.1-1.8-sqlite_file]
+[testenv:pypy-2.8.7-1.9-sqlite]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.8,<1.9
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.9,<1.10
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 32
 
 
-[testenv:pypy-2.8.1-1.9-sqlite]
+[testenv:pypy-2.8.7-1.9-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 33
 
 
-[testenv:pypy-2.8.1-1.9-sqlite_file]
+[testenv:pypy-2.8.7-master-sqlite]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.9,<1.10
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    https://github.com/django/django/archive/master.tar.gz
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 34
 
 
-[testenv:pypy-2.8.1-master-sqlite]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
-basepython = pypy
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
-    south==1.0.2
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 35
-
-
-[testenv:pypy-2.8.1-master-sqlite_file]
+[testenv:pypy-2.8.7-master-sqlite_file]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 36
+     UID = 35
 
 
 [testenv:pypy3-2.7.3-1.5-sqlite]
@@ -512,12 +502,12 @@ commands =
 basepython = pypy3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 37
+     UID = 36
 
 
 [testenv:pypy3-2.7.3-1.5-sqlite_file]
@@ -526,12 +516,12 @@ commands =
 basepython = pypy3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 38
+     UID = 37
 
 
 [testenv:pypy3-2.7.3-1.6-sqlite]
@@ -540,12 +530,12 @@ commands =
 basepython = pypy3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 39
+     UID = 38
 
 
 [testenv:pypy3-2.7.3-1.6-sqlite_file]
@@ -554,12 +544,12 @@ commands =
 basepython = pypy3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 40
+     UID = 39
 
 
 [testenv:pypy3-2.7.3-1.7-sqlite]
@@ -568,12 +558,12 @@ commands =
 basepython = pypy3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 41
+     UID = 40
 
 
 [testenv:pypy3-2.7.3-1.7-sqlite_file]
@@ -582,12 +572,12 @@ commands =
 basepython = pypy3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 42
+     UID = 41
 
 
 [testenv:pypy3-2.7.3-1.8-sqlite]
@@ -596,12 +586,12 @@ commands =
 basepython = pypy3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 43
+     UID = 42
 
 
 [testenv:pypy3-2.7.3-1.8-sqlite_file]
@@ -610,136 +600,153 @@ commands =
 basepython = pypy3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 43
+
+
+[testenv:pypy3-2.8.7-1.5-sqlite]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+basepython = pypy3
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.5,<1.6
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 44
 
 
-[testenv:pypy3-2.8.1-1.5-sqlite]
+[testenv:pypy3-2.8.7-1.5-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 45
 
 
-[testenv:pypy3-2.8.1-1.5-sqlite_file]
+[testenv:pypy3-2.8.7-1.6-sqlite]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = pypy3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.6,<1.7
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 46
 
 
-[testenv:pypy3-2.8.1-1.6-sqlite]
+[testenv:pypy3-2.8.7-1.6-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 47
 
 
-[testenv:pypy3-2.8.1-1.6-sqlite_file]
+[testenv:pypy3-2.8.7-1.7-sqlite]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = pypy3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.7,<1.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 48
 
 
-[testenv:pypy3-2.8.1-1.7-sqlite]
+[testenv:pypy3-2.8.7-1.7-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 49
 
 
-[testenv:pypy3-2.8.1-1.7-sqlite_file]
+[testenv:pypy3-2.8.7-1.8-sqlite]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = pypy3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.7,<1.8
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.8,<1.9
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 50
 
 
-[testenv:pypy3-2.8.1-1.8-sqlite]
+[testenv:pypy3-2.8.7-1.8-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = pypy3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 51
 
 
-[testenv:pypy3-2.8.1-1.8-sqlite_file]
+[testenv:python2.6-2.7.3-1.4-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = pypy3
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_52; create database pytest_django_52'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.8,<1.9
-    django-configurations==0.8
+    pytest==2.7.3
+    pytest-xdist==1.14
+    Django>=1.4,<1.5
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 52
 
 
-[testenv:python2.6-2.7.3-1.4-mysql_innodb]
+[testenv:python2.6-2.7.3-1.4-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_53; create database pytest_django_53'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -747,38 +754,21 @@ setenv =
      UID = 53
 
 
-[testenv:python2.6-2.7.3-1.4-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_54; create database pytest_django_54'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.6
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.4,<1.5
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 54
-
-
 [testenv:python2.6-2.7.3-1.4-postgres]
 commands =
-    sh -c "dropdb pytest_django_55; createdb pytest_django_55 || exit 0"
+    sh -c "dropdb pytest_django_54; createdb pytest_django_54 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 55
+     UID = 54
 
 
 [testenv:python2.6-2.7.3-1.4-sqlite]
@@ -787,13 +777,13 @@ commands =
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 56
+     UID = 55
 
 
 [testenv:python2.6-2.7.3-1.4-sqlite_file]
@@ -802,25 +792,42 @@ commands =
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 56
+
+
+[testenv:python2.6-2.7.3-1.5-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_57; create database pytest_django_57'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.6
+deps =
+    pytest==2.7.3
+    pytest-xdist==1.14
+    Django>=1.5,<1.6
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 57
 
 
-[testenv:python2.6-2.7.3-1.5-mysql_innodb]
+[testenv:python2.6-2.7.3-1.5-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_58; create database pytest_django_58'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -828,38 +835,21 @@ setenv =
      UID = 58
 
 
-[testenv:python2.6-2.7.3-1.5-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_59; create database pytest_django_59'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.6
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 59
-
-
 [testenv:python2.6-2.7.3-1.5-postgres]
 commands =
-    sh -c "dropdb pytest_django_60; createdb pytest_django_60 || exit 0"
+    sh -c "dropdb pytest_django_59; createdb pytest_django_59 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 60
+     UID = 59
 
 
 [testenv:python2.6-2.7.3-1.5-sqlite]
@@ -868,13 +858,13 @@ commands =
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 61
+     UID = 60
 
 
 [testenv:python2.6-2.7.3-1.5-sqlite_file]
@@ -883,25 +873,42 @@ commands =
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 61
+
+
+[testenv:python2.6-2.7.3-1.6-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_62; create database pytest_django_62'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.6
+deps =
+    pytest==2.7.3
+    pytest-xdist==1.14
+    Django>=1.6,<1.7
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 62
 
 
-[testenv:python2.6-2.7.3-1.6-mysql_innodb]
+[testenv:python2.6-2.7.3-1.6-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_63; create database pytest_django_63'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -909,38 +916,21 @@ setenv =
      UID = 63
 
 
-[testenv:python2.6-2.7.3-1.6-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_64; create database pytest_django_64'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.6
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 64
-
-
 [testenv:python2.6-2.7.3-1.6-postgres]
 commands =
-    sh -c "dropdb pytest_django_65; createdb pytest_django_65 || exit 0"
+    sh -c "dropdb pytest_django_64; createdb pytest_django_64 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 65
+     UID = 64
 
 
 [testenv:python2.6-2.7.3-1.6-sqlite]
@@ -949,13 +939,13 @@ commands =
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 66
+     UID = 65
 
 
 [testenv:python2.6-2.7.3-1.6-sqlite_file]
@@ -964,25 +954,42 @@ commands =
 basepython = python2.6
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 66
+
+
+[testenv:python2.6-2.8.7-1.4-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_67; create database pytest_django_67'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.6
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.4,<1.5
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 67
 
 
-[testenv:python2.6-2.8.1-1.4-mysql_innodb]
+[testenv:python2.6-2.8.7-1.4-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_68; create database pytest_django_68'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -990,80 +997,80 @@ setenv =
      UID = 68
 
 
-[testenv:python2.6-2.8.1-1.4-mysql_myisam]
+[testenv:python2.6-2.8.7-1.4-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_69; create database pytest_django_69'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_69; createdb pytest_django_69 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 69
 
 
-[testenv:python2.6-2.8.1-1.4-postgres]
+[testenv:python2.6-2.8.7-1.4-sqlite]
 commands =
-    sh -c "dropdb pytest_django_70; createdb pytest_django_70 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 70
 
 
-[testenv:python2.6-2.8.1-1.4-sqlite]
+[testenv:python2.6-2.8.7-1.4-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 71
 
 
-[testenv:python2.6-2.8.1-1.4-sqlite_file]
+[testenv:python2.6-2.8.7-1.5-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_72; create database pytest_django_72'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.4,<1.5
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.5,<1.6
+    django-configurations==1.0
     south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 72
 
 
-[testenv:python2.6-2.8.1-1.5-mysql_innodb]
+[testenv:python2.6-2.8.7-1.5-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_73; create database pytest_django_73'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1071,80 +1078,80 @@ setenv =
      UID = 73
 
 
-[testenv:python2.6-2.8.1-1.5-mysql_myisam]
+[testenv:python2.6-2.8.7-1.5-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_74; create database pytest_django_74'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_74; createdb pytest_django_74 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 74
 
 
-[testenv:python2.6-2.8.1-1.5-postgres]
+[testenv:python2.6-2.8.7-1.5-sqlite]
 commands =
-    sh -c "dropdb pytest_django_75; createdb pytest_django_75 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 75
 
 
-[testenv:python2.6-2.8.1-1.5-sqlite]
+[testenv:python2.6-2.8.7-1.5-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 76
 
 
-[testenv:python2.6-2.8.1-1.5-sqlite_file]
+[testenv:python2.6-2.8.7-1.6-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_77; create database pytest_django_77'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.6,<1.7
+    django-configurations==1.0
     south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 77
 
 
-[testenv:python2.6-2.8.1-1.6-mysql_innodb]
+[testenv:python2.6-2.8.7-1.6-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_78; create database pytest_django_78'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1152,80 +1159,80 @@ setenv =
      UID = 78
 
 
-[testenv:python2.6-2.8.1-1.6-mysql_myisam]
+[testenv:python2.6-2.8.7-1.6-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_79; create database pytest_django_79'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_79; createdb pytest_django_79 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 79
 
 
-[testenv:python2.6-2.8.1-1.6-postgres]
+[testenv:python2.6-2.8.7-1.6-sqlite]
 commands =
-    sh -c "dropdb pytest_django_80; createdb pytest_django_80 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 80
 
 
-[testenv:python2.6-2.8.1-1.6-sqlite]
+[testenv:python2.6-2.8.7-1.6-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.6
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 81
 
 
-[testenv:python2.6-2.8.1-1.6-sqlite_file]
+[testenv:python2.7-2.7.3-1.4-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python2.6
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_82; create database pytest_django_82'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
+    pytest==2.7.3
+    pytest-xdist==1.14
+    Django>=1.4,<1.5
+    django-configurations==1.0
     south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 82
 
 
-[testenv:python2.7-2.7.3-1.4-mysql_innodb]
+[testenv:python2.7-2.7.3-1.4-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_83; create database pytest_django_83'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1233,38 +1240,21 @@ setenv =
      UID = 83
 
 
-[testenv:python2.7-2.7.3-1.4-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_84; create database pytest_django_84'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.7
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.4,<1.5
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 84
-
-
 [testenv:python2.7-2.7.3-1.4-postgres]
 commands =
-    sh -c "dropdb pytest_django_85; createdb pytest_django_85 || exit 0"
+    sh -c "dropdb pytest_django_84; createdb pytest_django_84 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 85
+     UID = 84
 
 
 [testenv:python2.7-2.7.3-1.4-sqlite]
@@ -1273,13 +1263,13 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 86
+     UID = 85
 
 
 [testenv:python2.7-2.7.3-1.4-sqlite_file]
@@ -1288,25 +1278,42 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 86
+
+
+[testenv:python2.7-2.7.3-1.5-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_87; create database pytest_django_87'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.7
+deps =
+    pytest==2.7.3
+    pytest-xdist==1.14
+    Django>=1.5,<1.6
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 87
 
 
-[testenv:python2.7-2.7.3-1.5-mysql_innodb]
+[testenv:python2.7-2.7.3-1.5-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_88; create database pytest_django_88'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1314,38 +1321,21 @@ setenv =
      UID = 88
 
 
-[testenv:python2.7-2.7.3-1.5-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_89; create database pytest_django_89'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.7
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 89
-
-
 [testenv:python2.7-2.7.3-1.5-postgres]
 commands =
-    sh -c "dropdb pytest_django_90; createdb pytest_django_90 || exit 0"
+    sh -c "dropdb pytest_django_89; createdb pytest_django_89 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 90
+     UID = 89
 
 
 [testenv:python2.7-2.7.3-1.5-sqlite]
@@ -1354,13 +1344,13 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 91
+     UID = 90
 
 
 [testenv:python2.7-2.7.3-1.5-sqlite_file]
@@ -1369,25 +1359,42 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 91
+
+
+[testenv:python2.7-2.7.3-1.6-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_92; create database pytest_django_92'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.7
+deps =
+    pytest==2.7.3
+    pytest-xdist==1.14
+    Django>=1.6,<1.7
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 92
 
 
-[testenv:python2.7-2.7.3-1.6-mysql_innodb]
+[testenv:python2.7-2.7.3-1.6-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_93; create database pytest_django_93'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1395,38 +1402,21 @@ setenv =
      UID = 93
 
 
-[testenv:python2.7-2.7.3-1.6-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_94; create database pytest_django_94'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.7
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 94
-
-
 [testenv:python2.7-2.7.3-1.6-postgres]
 commands =
-    sh -c "dropdb pytest_django_95; createdb pytest_django_95 || exit 0"
+    sh -c "dropdb pytest_django_94; createdb pytest_django_94 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 95
+     UID = 94
 
 
 [testenv:python2.7-2.7.3-1.6-sqlite]
@@ -1435,13 +1425,13 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 96
+     UID = 95
 
 
 [testenv:python2.7-2.7.3-1.6-sqlite_file]
@@ -1450,25 +1440,42 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 96
+
+
+[testenv:python2.7-2.7.3-1.7-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_97; create database pytest_django_97'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.7
+deps =
+    pytest==2.7.3
+    pytest-xdist==1.14
+    Django>=1.7,<1.8
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 97
 
 
-[testenv:python2.7-2.7.3-1.7-mysql_innodb]
+[testenv:python2.7-2.7.3-1.7-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_98; create database pytest_django_98'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1476,38 +1483,21 @@ setenv =
      UID = 98
 
 
-[testenv:python2.7-2.7.3-1.7-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_99; create database pytest_django_99'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.7
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.7,<1.8
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 99
-
-
 [testenv:python2.7-2.7.3-1.7-postgres]
 commands =
-    sh -c "dropdb pytest_django_100; createdb pytest_django_100 || exit 0"
+    sh -c "dropdb pytest_django_99; createdb pytest_django_99 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 100
+     UID = 99
 
 
 [testenv:python2.7-2.7.3-1.7-sqlite]
@@ -1516,13 +1506,13 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 101
+     UID = 100
 
 
 [testenv:python2.7-2.7.3-1.7-sqlite_file]
@@ -1531,25 +1521,42 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 101
+
+
+[testenv:python2.7-2.7.3-1.8-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_102; create database pytest_django_102'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.7
+deps =
+    pytest==2.7.3
+    pytest-xdist==1.14
+    Django>=1.8,<1.9
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 102
 
 
-[testenv:python2.7-2.7.3-1.8-mysql_innodb]
+[testenv:python2.7-2.7.3-1.8-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_103; create database pytest_django_103'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1557,38 +1564,21 @@ setenv =
      UID = 103
 
 
-[testenv:python2.7-2.7.3-1.8-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_104; create database pytest_django_104'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.7
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.8,<1.9
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 104
-
-
 [testenv:python2.7-2.7.3-1.8-postgres]
 commands =
-    sh -c "dropdb pytest_django_105; createdb pytest_django_105 || exit 0"
+    sh -c "dropdb pytest_django_104; createdb pytest_django_104 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 105
+     UID = 104
 
 
 [testenv:python2.7-2.7.3-1.8-sqlite]
@@ -1597,13 +1587,13 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 106
+     UID = 105
 
 
 [testenv:python2.7-2.7.3-1.8-sqlite_file]
@@ -1612,25 +1602,42 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 106
+
+
+[testenv:python2.7-2.7.3-1.9-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_107; create database pytest_django_107'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.7
+deps =
+    pytest==2.7.3
+    pytest-xdist==1.14
+    Django>=1.9,<1.10
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 107
 
 
-[testenv:python2.7-2.7.3-1.9-mysql_innodb]
+[testenv:python2.7-2.7.3-1.9-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_108; create database pytest_django_108'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1638,38 +1645,21 @@ setenv =
      UID = 108
 
 
-[testenv:python2.7-2.7.3-1.9-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_109; create database pytest_django_109'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.7
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.9,<1.10
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 109
-
-
 [testenv:python2.7-2.7.3-1.9-postgres]
 commands =
-    sh -c "dropdb pytest_django_110; createdb pytest_django_110 || exit 0"
+    sh -c "dropdb pytest_django_109; createdb pytest_django_109 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 110
+     UID = 109
 
 
 [testenv:python2.7-2.7.3-1.9-sqlite]
@@ -1678,13 +1668,13 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 111
+     UID = 110
 
 
 [testenv:python2.7-2.7.3-1.9-sqlite_file]
@@ -1693,25 +1683,42 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 111
+
+
+[testenv:python2.7-2.7.3-master-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_112; create database pytest_django_112'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.7
+deps =
+    pytest==2.7.3
+    pytest-xdist==1.14
+    https://github.com/django/django/archive/master.tar.gz
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 112
 
 
-[testenv:python2.7-2.7.3-master-mysql_innodb]
+[testenv:python2.7-2.7.3-master-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_113; create database pytest_django_113'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1719,38 +1726,21 @@ setenv =
      UID = 113
 
 
-[testenv:python2.7-2.7.3-master-mysql_myisam]
-commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_114; create database pytest_django_114'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
-basepython = python2.7
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
-    south==1.0.2
-    mysql-python==1.2.5
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 114
-
-
 [testenv:python2.7-2.7.3-master-postgres]
 commands =
-    sh -c "dropdb pytest_django_115; createdb pytest_django_115 || exit 0"
+    sh -c "dropdb pytest_django_114; createdb pytest_django_114 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 115
+     UID = 114
 
 
 [testenv:python2.7-2.7.3-master-sqlite]
@@ -1759,13 +1749,13 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 116
+     UID = 115
 
 
 [testenv:python2.7-2.7.3-master-sqlite_file]
@@ -1774,25 +1764,42 @@ commands =
 basepython = python2.7
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 116
+
+
+[testenv:python2.7-2.8.7-1.4-mysql_innodb]
+commands =
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_117; create database pytest_django_117'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+basepython = python2.7
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.4,<1.5
+    django-configurations==1.0
+    south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 117
 
 
-[testenv:python2.7-2.8.1-1.4-mysql_innodb]
+[testenv:python2.7-2.8.7-1.4-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_118; create database pytest_django_118'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1800,80 +1807,80 @@ setenv =
      UID = 118
 
 
-[testenv:python2.7-2.8.1-1.4-mysql_myisam]
+[testenv:python2.7-2.8.7-1.4-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_119; create database pytest_django_119'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_119; createdb pytest_django_119 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 119
 
 
-[testenv:python2.7-2.8.1-1.4-postgres]
+[testenv:python2.7-2.8.7-1.4-sqlite]
 commands =
-    sh -c "dropdb pytest_django_120; createdb pytest_django_120 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 120
 
 
-[testenv:python2.7-2.8.1-1.4-sqlite]
+[testenv:python2.7-2.8.7-1.4-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.4,<1.5
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 121
 
 
-[testenv:python2.7-2.8.1-1.4-sqlite_file]
+[testenv:python2.7-2.8.7-1.5-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_122; create database pytest_django_122'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.4,<1.5
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.5,<1.6
+    django-configurations==1.0
     south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 122
 
 
-[testenv:python2.7-2.8.1-1.5-mysql_innodb]
+[testenv:python2.7-2.8.7-1.5-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_123; create database pytest_django_123'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1881,80 +1888,80 @@ setenv =
      UID = 123
 
 
-[testenv:python2.7-2.8.1-1.5-mysql_myisam]
+[testenv:python2.7-2.8.7-1.5-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_124; create database pytest_django_124'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_124; createdb pytest_django_124 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 124
 
 
-[testenv:python2.7-2.8.1-1.5-postgres]
+[testenv:python2.7-2.8.7-1.5-sqlite]
 commands =
-    sh -c "dropdb pytest_django_125; createdb pytest_django_125 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 125
 
 
-[testenv:python2.7-2.8.1-1.5-sqlite]
+[testenv:python2.7-2.8.7-1.5-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 126
 
 
-[testenv:python2.7-2.8.1-1.5-sqlite_file]
+[testenv:python2.7-2.8.7-1.6-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_127; create database pytest_django_127'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.6,<1.7
+    django-configurations==1.0
     south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 127
 
 
-[testenv:python2.7-2.8.1-1.6-mysql_innodb]
+[testenv:python2.7-2.8.7-1.6-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_128; create database pytest_django_128'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -1962,80 +1969,80 @@ setenv =
      UID = 128
 
 
-[testenv:python2.7-2.8.1-1.6-mysql_myisam]
+[testenv:python2.7-2.8.7-1.6-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_129; create database pytest_django_129'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_129; createdb pytest_django_129 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 129
 
 
-[testenv:python2.7-2.8.1-1.6-postgres]
+[testenv:python2.7-2.8.7-1.6-sqlite]
 commands =
-    sh -c "dropdb pytest_django_130; createdb pytest_django_130 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 130
 
 
-[testenv:python2.7-2.8.1-1.6-sqlite]
+[testenv:python2.7-2.8.7-1.6-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 131
 
 
-[testenv:python2.7-2.8.1-1.6-sqlite_file]
+[testenv:python2.7-2.8.7-1.7-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_132; create database pytest_django_132'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.7,<1.8
+    django-configurations==1.0
     south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 132
 
 
-[testenv:python2.7-2.8.1-1.7-mysql_innodb]
+[testenv:python2.7-2.8.7-1.7-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_133; create database pytest_django_133'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -2043,80 +2050,80 @@ setenv =
      UID = 133
 
 
-[testenv:python2.7-2.8.1-1.7-mysql_myisam]
+[testenv:python2.7-2.8.7-1.7-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_134; create database pytest_django_134'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_134; createdb pytest_django_134 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 134
 
 
-[testenv:python2.7-2.8.1-1.7-postgres]
+[testenv:python2.7-2.8.7-1.7-sqlite]
 commands =
-    sh -c "dropdb pytest_django_135; createdb pytest_django_135 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 135
 
 
-[testenv:python2.7-2.8.1-1.7-sqlite]
+[testenv:python2.7-2.8.7-1.7-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 136
 
 
-[testenv:python2.7-2.8.1-1.7-sqlite_file]
+[testenv:python2.7-2.8.7-1.8-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_137; create database pytest_django_137'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.7,<1.8
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.8,<1.9
+    django-configurations==1.0
     south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 137
 
 
-[testenv:python2.7-2.8.1-1.8-mysql_innodb]
+[testenv:python2.7-2.8.7-1.8-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_138; create database pytest_django_138'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -2124,80 +2131,80 @@ setenv =
      UID = 138
 
 
-[testenv:python2.7-2.8.1-1.8-mysql_myisam]
+[testenv:python2.7-2.8.7-1.8-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_139; create database pytest_django_139'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_139; createdb pytest_django_139 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 139
 
 
-[testenv:python2.7-2.8.1-1.8-postgres]
+[testenv:python2.7-2.8.7-1.8-sqlite]
 commands =
-    sh -c "dropdb pytest_django_140; createdb pytest_django_140 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 140
 
 
-[testenv:python2.7-2.8.1-1.8-sqlite]
+[testenv:python2.7-2.8.7-1.8-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 141
 
 
-[testenv:python2.7-2.8.1-1.8-sqlite_file]
+[testenv:python2.7-2.8.7-1.9-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_142; create database pytest_django_142'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.8,<1.9
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.9,<1.10
+    django-configurations==1.0
     south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 142
 
 
-[testenv:python2.7-2.8.1-1.9-mysql_innodb]
+[testenv:python2.7-2.8.7-1.9-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_143; create database pytest_django_143'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -2205,80 +2212,80 @@ setenv =
      UID = 143
 
 
-[testenv:python2.7-2.8.1-1.9-mysql_myisam]
+[testenv:python2.7-2.8.7-1.9-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_144; create database pytest_django_144'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_144; createdb pytest_django_144 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 144
 
 
-[testenv:python2.7-2.8.1-1.9-postgres]
+[testenv:python2.7-2.8.7-1.9-sqlite]
 commands =
-    sh -c "dropdb pytest_django_145; createdb pytest_django_145 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 145
 
 
-[testenv:python2.7-2.8.1-1.9-sqlite]
+[testenv:python2.7-2.8.7-1.9-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 146
 
 
-[testenv:python2.7-2.8.1-1.9-sqlite_file]
+[testenv:python2.7-2.8.7-master-mysql_innodb]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    sh -c "mysql -u root -e 'drop database if exists pytest_django_147; create database pytest_django_147'" || exit 0
+    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.9,<1.10
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    https://github.com/django/django/archive/master.tar.gz
+    django-configurations==1.0
     south==1.0.2
+    mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 147
 
 
-[testenv:python2.7-2.8.1-master-mysql_innodb]
+[testenv:python2.7-2.8.7-master-mysql_myisam]
 commands =
     sh -c "mysql -u root -e 'drop database if exists pytest_django_148; create database pytest_django_148'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
     mysql-python==1.2.5
 setenv =
@@ -2286,260 +2293,67 @@ setenv =
      UID = 148
 
 
-[testenv:python2.7-2.8.1-master-mysql_myisam]
+[testenv:python2.7-2.8.7-master-postgres]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_149; create database pytest_django_149'" || exit 0
-    py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_149; createdb pytest_django_149 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    mysql-python==1.2.5
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 149
 
 
-[testenv:python2.7-2.8.1-master-postgres]
+[testenv:python2.7-2.8.7-master-sqlite]
 commands =
-    sh -c "dropdb pytest_django_150; createdb pytest_django_150 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
-    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 150
 
 
-[testenv:python2.7-2.8.1-master-sqlite]
+[testenv:python2.7-2.8.7-master-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     south==1.0.2
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 151
 
 
-[testenv:python2.7-2.8.1-master-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python2.7
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
-    south==1.0.2
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 152
-
-
-[testenv:python3.2-2.7.3-1.5-postgres]
-commands =
-    sh -c "dropdb pytest_django_153; createdb pytest_django_153 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
-    psycopg2==2.6.1
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 153
-
-
-[testenv:python3.2-2.7.3-1.5-sqlite]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 154
-
-
-[testenv:python3.2-2.7.3-1.5-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 155
-
-
-[testenv:python3.2-2.7.3-1.6-postgres]
-commands =
-    sh -c "dropdb pytest_django_156; createdb pytest_django_156 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-    psycopg2==2.6.1
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 156
-
-
-[testenv:python3.2-2.7.3-1.6-sqlite]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 157
-
-
-[testenv:python3.2-2.7.3-1.6-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.7.3
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 158
-
-
-[testenv:python3.2-2.8.1-1.5-postgres]
-commands =
-    sh -c "dropdb pytest_django_159; createdb pytest_django_159 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
-    psycopg2==2.6.1
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 159
-
-
-[testenv:python3.2-2.8.1-1.5-sqlite]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 160
-
-
-[testenv:python3.2-2.8.1-1.5-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 161
-
-
-[testenv:python3.2-2.8.1-1.6-postgres]
-commands =
-    sh -c "dropdb pytest_django_162; createdb pytest_django_162 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-    psycopg2==2.6.1
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 162
-
-
-[testenv:python3.2-2.8.1-1.6-sqlite]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 163
-
-
-[testenv:python3.2-2.8.1-1.6-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python3.2
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 164
-
-
 [testenv:python3.3-2.7.3-1.5-postgres]
 commands =
-    sh -c "dropdb pytest_django_165; createdb pytest_django_165 || exit 0"
+    sh -c "dropdb pytest_django_152; createdb pytest_django_152 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 165
+     UID = 152
 
 
 [testenv:python3.3-2.7.3-1.5-sqlite]
@@ -2548,12 +2362,12 @@ commands =
 basepython = python3.3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 166
+     UID = 153
 
 
 [testenv:python3.3-2.7.3-1.5-sqlite_file]
@@ -2562,28 +2376,28 @@ commands =
 basepython = python3.3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 167
+     UID = 154
 
 
 [testenv:python3.3-2.7.3-1.6-postgres]
 commands =
-    sh -c "dropdb pytest_django_168; createdb pytest_django_168 || exit 0"
+    sh -c "dropdb pytest_django_155; createdb pytest_django_155 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 168
+     UID = 155
 
 
 [testenv:python3.3-2.7.3-1.6-sqlite]
@@ -2592,12 +2406,12 @@ commands =
 basepython = python3.3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 169
+     UID = 156
 
 
 [testenv:python3.3-2.7.3-1.6-sqlite_file]
@@ -2606,116 +2420,116 @@ commands =
 basepython = python3.3
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 170
+     UID = 157
 
 
-[testenv:python3.3-2.8.1-1.5-postgres]
+[testenv:python3.3-2.8.7-1.5-postgres]
 commands =
-    sh -c "dropdb pytest_django_171; createdb pytest_django_171 || exit 0"
+    sh -c "dropdb pytest_django_158; createdb pytest_django_158 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 171
+     UID = 158
 
 
-[testenv:python3.3-2.8.1-1.5-sqlite]
+[testenv:python3.3-2.8.7-1.5-sqlite]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 172
+     UID = 159
 
 
-[testenv:python3.3-2.8.1-1.5-sqlite_file]
+[testenv:python3.3-2.8.7-1.5-sqlite_file]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 173
+     UID = 160
 
 
-[testenv:python3.3-2.8.1-1.6-postgres]
+[testenv:python3.3-2.8.7-1.6-postgres]
 commands =
-    sh -c "dropdb pytest_django_174; createdb pytest_django_174 || exit 0"
+    sh -c "dropdb pytest_django_161; createdb pytest_django_161 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 174
+     UID = 161
 
 
-[testenv:python3.3-2.8.1-1.6-sqlite]
+[testenv:python3.3-2.8.7-1.6-sqlite]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 175
+     UID = 162
 
 
-[testenv:python3.3-2.8.1-1.6-sqlite_file]
+[testenv:python3.3-2.8.7-1.6-sqlite_file]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 176
+     UID = 163
 
 
 [testenv:python3.4-2.7.3-1.5-postgres]
 commands =
-    sh -c "dropdb pytest_django_177; createdb pytest_django_177 || exit 0"
+    sh -c "dropdb pytest_django_164; createdb pytest_django_164 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 177
+     UID = 164
 
 
 [testenv:python3.4-2.7.3-1.5-sqlite]
@@ -2724,12 +2538,12 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 178
+     UID = 165
 
 
 [testenv:python3.4-2.7.3-1.5-sqlite_file]
@@ -2738,28 +2552,28 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.5,<1.6
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 179
+     UID = 166
 
 
 [testenv:python3.4-2.7.3-1.6-postgres]
 commands =
-    sh -c "dropdb pytest_django_180; createdb pytest_django_180 || exit 0"
+    sh -c "dropdb pytest_django_167; createdb pytest_django_167 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 180
+     UID = 167
 
 
 [testenv:python3.4-2.7.3-1.6-sqlite]
@@ -2768,12 +2582,12 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 181
+     UID = 168
 
 
 [testenv:python3.4-2.7.3-1.6-sqlite_file]
@@ -2782,28 +2596,28 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.6,<1.7
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 182
+     UID = 169
 
 
 [testenv:python3.4-2.7.3-1.7-postgres]
 commands =
-    sh -c "dropdb pytest_django_183; createdb pytest_django_183 || exit 0"
+    sh -c "dropdb pytest_django_170; createdb pytest_django_170 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 183
+     UID = 170
 
 
 [testenv:python3.4-2.7.3-1.7-sqlite]
@@ -2812,12 +2626,12 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 184
+     UID = 171
 
 
 [testenv:python3.4-2.7.3-1.7-sqlite_file]
@@ -2826,28 +2640,28 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.7,<1.8
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 185
+     UID = 172
 
 
 [testenv:python3.4-2.7.3-1.8-postgres]
 commands =
-    sh -c "dropdb pytest_django_186; createdb pytest_django_186 || exit 0"
+    sh -c "dropdb pytest_django_173; createdb pytest_django_173 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 186
+     UID = 173
 
 
 [testenv:python3.4-2.7.3-1.8-sqlite]
@@ -2856,12 +2670,12 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 187
+     UID = 174
 
 
 [testenv:python3.4-2.7.3-1.8-sqlite_file]
@@ -2870,28 +2684,28 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 188
+     UID = 175
 
 
 [testenv:python3.4-2.7.3-1.9-postgres]
 commands =
-    sh -c "dropdb pytest_django_189; createdb pytest_django_189 || exit 0"
+    sh -c "dropdb pytest_django_176; createdb pytest_django_176 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 189
+     UID = 176
 
 
 [testenv:python3.4-2.7.3-1.9-sqlite]
@@ -2900,12 +2714,12 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 190
+     UID = 177
 
 
 [testenv:python3.4-2.7.3-1.9-sqlite_file]
@@ -2914,28 +2728,28 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 191
+     UID = 178
 
 
 [testenv:python3.4-2.7.3-master-postgres]
 commands =
-    sh -c "dropdb pytest_django_192; createdb pytest_django_192 || exit 0"
+    sh -c "dropdb pytest_django_179; createdb pytest_django_179 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 192
+     UID = 179
 
 
 [testenv:python3.4-2.7.3-master-sqlite]
@@ -2944,12 +2758,12 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 193
+     UID = 180
 
 
 [testenv:python3.4-2.7.3-master-sqlite_file]
@@ -2958,292 +2772,292 @@ commands =
 basepython = python3.4
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 181
+
+
+[testenv:python3.4-2.8.7-1.5-postgres]
+commands =
+    sh -c "dropdb pytest_django_182; createdb pytest_django_182 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.5,<1.6
+    django-configurations==1.0
+    psycopg2==2.6.1
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 182
+
+
+[testenv:python3.4-2.8.7-1.5-sqlite]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.5,<1.6
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 183
+
+
+[testenv:python3.4-2.8.7-1.5-sqlite_file]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.5,<1.6
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 184
+
+
+[testenv:python3.4-2.8.7-1.6-postgres]
+commands =
+    sh -c "dropdb pytest_django_185; createdb pytest_django_185 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.6,<1.7
+    django-configurations==1.0
+    psycopg2==2.6.1
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 185
+
+
+[testenv:python3.4-2.8.7-1.6-sqlite]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.6,<1.7
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 186
+
+
+[testenv:python3.4-2.8.7-1.6-sqlite_file]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.6,<1.7
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 187
+
+
+[testenv:python3.4-2.8.7-1.7-postgres]
+commands =
+    sh -c "dropdb pytest_django_188; createdb pytest_django_188 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.7,<1.8
+    django-configurations==1.0
+    psycopg2==2.6.1
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 188
+
+
+[testenv:python3.4-2.8.7-1.7-sqlite]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.7,<1.8
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 189
+
+
+[testenv:python3.4-2.8.7-1.7-sqlite_file]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.7,<1.8
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 190
+
+
+[testenv:python3.4-2.8.7-1.8-postgres]
+commands =
+    sh -c "dropdb pytest_django_191; createdb pytest_django_191 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.8,<1.9
+    django-configurations==1.0
+    psycopg2==2.6.1
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 191
+
+
+[testenv:python3.4-2.8.7-1.8-sqlite]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.8,<1.9
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 192
+
+
+[testenv:python3.4-2.8.7-1.8-sqlite_file]
+commands =
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.8,<1.9
+    django-configurations==1.0
+setenv =
+     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
+     UID = 193
+
+
+[testenv:python3.4-2.8.7-1.9-postgres]
+commands =
+    sh -c "dropdb pytest_django_194; createdb pytest_django_194 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+basepython = python3.4
+deps =
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.9,<1.10
+    django-configurations==1.0
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 194
 
 
-[testenv:python3.4-2.8.1-1.5-postgres]
+[testenv:python3.4-2.8.7-1.9-sqlite]
 commands =
-    sh -c "dropdb pytest_django_195; createdb pytest_django_195 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
-    psycopg2==2.6.1
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.9,<1.10
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 195
 
 
-[testenv:python3.4-2.8.1-1.5-sqlite]
+[testenv:python3.4-2.8.7-1.9-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    Django>=1.9,<1.10
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 196
 
 
-[testenv:python3.4-2.8.1-1.5-sqlite_file]
+[testenv:python3.4-2.8.7-master-postgres]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
+    sh -c "dropdb pytest_django_197; createdb pytest_django_197 || exit 0"
+    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.5,<1.6
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    https://github.com/django/django/archive/master.tar.gz
+    django-configurations==1.0
+    psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 197
 
 
-[testenv:python3.4-2.8.1-1.6-postgres]
+[testenv:python3.4-2.8.7-master-sqlite]
 commands =
-    sh -c "dropdb pytest_django_198; createdb pytest_django_198 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-    psycopg2==2.6.1
+    pytest==2.8.7
+    pytest-xdist==1.14
+    https://github.com/django/django/archive/master.tar.gz
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 198
 
 
-[testenv:python3.4-2.8.1-1.6-sqlite]
+[testenv:python3.4-2.8.7-master-sqlite_file]
 commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
+    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
+    pytest==2.8.7
+    pytest-xdist==1.14
+    https://github.com/django/django/archive/master.tar.gz
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
      UID = 199
 
 
-[testenv:python3.4-2.8.1-1.6-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.6,<1.7
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 200
-
-
-[testenv:python3.4-2.8.1-1.7-postgres]
-commands =
-    sh -c "dropdb pytest_django_201; createdb pytest_django_201 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.7,<1.8
-    django-configurations==0.8
-    psycopg2==2.6.1
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 201
-
-
-[testenv:python3.4-2.8.1-1.7-sqlite]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.7,<1.8
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 202
-
-
-[testenv:python3.4-2.8.1-1.7-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.7,<1.8
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 203
-
-
-[testenv:python3.4-2.8.1-1.8-postgres]
-commands =
-    sh -c "dropdb pytest_django_204; createdb pytest_django_204 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.8,<1.9
-    django-configurations==0.8
-    psycopg2==2.6.1
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 204
-
-
-[testenv:python3.4-2.8.1-1.8-sqlite]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.8,<1.9
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 205
-
-
-[testenv:python3.4-2.8.1-1.8-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.8,<1.9
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 206
-
-
-[testenv:python3.4-2.8.1-1.9-postgres]
-commands =
-    sh -c "dropdb pytest_django_207; createdb pytest_django_207 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.9,<1.10
-    django-configurations==0.8
-    psycopg2==2.6.1
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 207
-
-
-[testenv:python3.4-2.8.1-1.9-sqlite]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.9,<1.10
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 208
-
-
-[testenv:python3.4-2.8.1-1.9-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    Django>=1.9,<1.10
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 209
-
-
-[testenv:python3.4-2.8.1-master-postgres]
-commands =
-    sh -c "dropdb pytest_django_210; createdb pytest_django_210 || exit 0"
-    py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
-    psycopg2==2.6.1
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 210
-
-
-[testenv:python3.4-2.8.1-master-sqlite]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 211
-
-
-[testenv:python3.4-2.8.1-master-sqlite_file]
-commands =
-    py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
-basepython = python3.4
-deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
-    https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
-setenv =
-     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 212
-
-
 [testenv:python3.5-2.7.3-1.8-postgres]
 commands =
-    sh -c "dropdb pytest_django_213; createdb pytest_django_213 || exit 0"
+    sh -c "dropdb pytest_django_200; createdb pytest_django_200 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 213
+     UID = 200
 
 
 [testenv:python3.5-2.7.3-1.8-sqlite]
@@ -3252,12 +3066,12 @@ commands =
 basepython = python3.5
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 214
+     UID = 201
 
 
 [testenv:python3.5-2.7.3-1.8-sqlite_file]
@@ -3266,28 +3080,28 @@ commands =
 basepython = python3.5
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 215
+     UID = 202
 
 
 [testenv:python3.5-2.7.3-1.9-postgres]
 commands =
-    sh -c "dropdb pytest_django_216; createdb pytest_django_216 || exit 0"
+    sh -c "dropdb pytest_django_203; createdb pytest_django_203 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 216
+     UID = 203
 
 
 [testenv:python3.5-2.7.3-1.9-sqlite]
@@ -3296,12 +3110,12 @@ commands =
 basepython = python3.5
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 217
+     UID = 204
 
 
 [testenv:python3.5-2.7.3-1.9-sqlite_file]
@@ -3310,28 +3124,28 @@ commands =
 basepython = python3.5
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 218
+     UID = 205
 
 
 [testenv:python3.5-2.7.3-master-postgres]
 commands =
-    sh -c "dropdb pytest_django_219; createdb pytest_django_219 || exit 0"
+    sh -c "dropdb pytest_django_206; createdb pytest_django_206 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 219
+     UID = 206
 
 
 [testenv:python3.5-2.7.3-master-sqlite]
@@ -3340,12 +3154,12 @@ commands =
 basepython = python3.5
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 220
+     UID = 207
 
 
 [testenv:python3.5-2.7.3-master-sqlite_file]
@@ -3354,141 +3168,141 @@ commands =
 basepython = python3.5
 deps =
     pytest==2.7.3
-    pytest-xdist==1.13.1
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 221
+     UID = 208
 
 
-[testenv:python3.5-2.8.1-1.8-postgres]
+[testenv:python3.5-2.8.7-1.8-postgres]
 commands =
-    sh -c "dropdb pytest_django_222; createdb pytest_django_222 || exit 0"
+    sh -c "dropdb pytest_django_209; createdb pytest_django_209 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 222
+     UID = 209
 
 
-[testenv:python3.5-2.8.1-1.8-sqlite]
+[testenv:python3.5-2.8.7-1.8-sqlite]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 223
+     UID = 210
 
 
-[testenv:python3.5-2.8.1-1.8-sqlite_file]
+[testenv:python3.5-2.8.7-1.8-sqlite_file]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.8,<1.9
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 224
+     UID = 211
 
 
-[testenv:python3.5-2.8.1-1.9-postgres]
+[testenv:python3.5-2.8.7-1.9-postgres]
 commands =
-    sh -c "dropdb pytest_django_225; createdb pytest_django_225 || exit 0"
+    sh -c "dropdb pytest_django_212; createdb pytest_django_212 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 225
+     UID = 212
 
 
-[testenv:python3.5-2.8.1-1.9-sqlite]
+[testenv:python3.5-2.8.7-1.9-sqlite]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 226
+     UID = 213
 
 
-[testenv:python3.5-2.8.1-1.9-sqlite_file]
+[testenv:python3.5-2.8.7-1.9-sqlite_file]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     Django>=1.9,<1.10
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 227
+     UID = 214
 
 
-[testenv:python3.5-2.8.1-master-postgres]
+[testenv:python3.5-2.8.7-master-postgres]
 commands =
-    sh -c "dropdb pytest_django_228; createdb pytest_django_228 || exit 0"
+    sh -c "dropdb pytest_django_215; createdb pytest_django_215 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 228
+     UID = 215
 
 
-[testenv:python3.5-2.8.1-master-sqlite]
+[testenv:python3.5-2.8.7-master-sqlite]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 229
+     UID = 216
 
 
-[testenv:python3.5-2.8.1-master-sqlite_file]
+[testenv:python3.5-2.8.7-master-sqlite_file]
 commands =
     py.test --ds=pytest_django_test.settings_sqlite_file --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
-    pytest==2.8.1
-    pytest-xdist==1.13.1
+    pytest==2.8.7
+    pytest-xdist==1.14
     https://github.com/django/django/archive/master.tar.gz
-    django-configurations==0.8
+    django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 230
+     UID = 217


### PR DESCRIPTION
Python 3.2 is not supported by pip 8+ anymore, which is used by tox via
Python 3.5's `virtualenv_support`.
Failing build: https://travis-ci.org/pytest-dev/pytest-django/jobs/106463859.