### PR TITLE
Remove reference to --no-db in command-line help

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -39,8 +39,7 @@ def pytest_addoption(parser):
     group._addoption('--reuse-db',
                      action='store_true', dest='reuse_db', default=False,
                      help='Re-use the testing database if it already exists, '
-                          'and do not remove it when the test finishes. This '
-                          'option will be ignored when --no-db is given.')
+                          'and do not remove it when the test finishes.')
     group._addoption('--create-db',
                      action='store_true', dest='create_db', default=False,
                      help='Re-create the database, even if it exists. This '


### PR DESCRIPTION
The `--reuse-db` option's help still mentions the `--no-db` option even though it was removed: https://github.com/pytest-dev/pytest-django/commit/bb7213bba53352fe56e563462deeaec92fbf2461#diff-87c0c2cb9262dd6c4384e140e51d8e64L69 