### PR TITLE
Fixed #136 - fix the settings fixture for certain settings.

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -270,7 +270,7 @@ def rf():
 
 
 class SettingsWrapper(object):
-    to_restore = []
+    _to_restore = []
 
     def __delattr__(self, attr):
         from django.test import override_settings
@@ -279,7 +279,7 @@ class SettingsWrapper(object):
         from django.conf import settings
         delattr(settings, attr)
 
-        self.to_restore.append(override)
+        self._to_restore.append(override)
 
     def __setattr__(self, attr, value):
         from django.test import override_settings
@@ -287,17 +287,17 @@ class SettingsWrapper(object):
             attr: value
         })
         override.enable()
-        self.to_restore.append(override)
+        self._to_restore.append(override)
 
     def __getattr__(self, item):
         from django.conf import settings
         return getattr(settings, item)
 
     def finalize(self):
-        for override in reversed(self.to_restore):
+        for override in reversed(self._to_restore):
             override.disable()
 
-        del self.to_restore[:]
+        del self._to_restore[:]
 
 
 @pytest.yield_fixture()

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -6,7 +6,6 @@ import os
 import warnings
 
 import pytest
-from django.test import override_settings
 
 from . import live_server_helper
 from .db_reuse import (monkey_patch_creation_for_db_reuse,
@@ -274,6 +273,7 @@ class SettingsWrapper(object):
     to_restore = []
 
     def __delattr__(self, attr):
+        from django.test import override_settings
         override = override_settings()
         override.enable()
         from django.conf import settings
@@ -282,6 +282,7 @@ class SettingsWrapper(object):
         self.to_restore.append(override)
 
     def __setattr__(self, attr, value):
+        from django.test import override_settings
         override = override_settings(**{
             attr: value
         })

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -297,7 +297,7 @@ class SettingsWrapper(object):
         for override in reversed(self.to_restore):
             override.disable()
 
-        self.to_restore.clear()
+        del self.to_restore[:]
 
 
 @pytest.yield_fixture()

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -269,60 +269,60 @@ def rf():
     return RequestFactory()
 
 
-def _delete_setting(test_node, settings, setting, enter):
-    from django.test.signals import setting_changed
-    delattr(settings, setting)
-    setting_changed.send(sender=test_node, setting=setting, value=None, enter=enter)
-
-
-def _set_setting(test_node, settings, setting, value, enter):
-    from django.test.signals import setting_changed
-    setattr(settings, setting, value)
-    setting_changed.send(sender=test_node, setting=setting, value=value, enter=enter)
-
-
-DOES_NOT_EXIST = object()
-
-
-class SettingsWrapper(object):
-    def __init__(self, node, django_settings):
-        super(SettingsWrapper, self).__setattr__('_node', node)
-        super(SettingsWrapper, self).__setattr__('_django_settings',
-                                                 django_settings)
-        super(SettingsWrapper, self).__setattr__('_to_restore', [])
+class BaseSettingsWrapper(object):
+    def __init__(self, monkeypatch, wrapped_object):
+        super(BaseSettingsWrapper, self).__setattr__('monkeypatch',
+                                                     monkeypatch)
+        super(BaseSettingsWrapper, self).__setattr__('wrapped_object',
+                                                     wrapped_object)
 
     def __getattr__(self, attr):
-        return getattr(self._django_settings, attr)
-
-    def _save_to_restore(self, attr):
-        self._to_restore.append((attr, getattr(self._django_settings, attr, DOES_NOT_EXIST)))
+        return getattr(self.wrapped_object, attr)
 
     def __setattr__(self, attr, value):
-        self._save_to_restore(attr)
-        _set_setting(self._node, self._django_settings, attr, value, enter=True)
+        self.monkeypatch.setattr(self.wrapped_object, attr, value,
+                                 raising=False)
 
     def __delattr__(self, attr):
-        self._save_to_restore(attr)
-        _delete_setting(self._node, self._django_settings, attr, enter=True)
-
-    def _restore(self):
-        for setting, old_value in reversed(self._to_restore):
-            if old_value is DOES_NOT_EXIST:
-                _delete_setting(self._node, self._django_settings, setting, enter=False)
-            else:
-                _set_setting(self._node, self._django_settings, setting, old_value, enter=False)
+        self.monkeypatch.delattr(self.wrapped_object, attr)
 
 
-@pytest.fixture()
-def settings(request, monkeypatch):
+class SettingsWrapper(BaseSettingsWrapper):
+    def __init__(self, monkeypatch):
+        wrapper = self.get_wrapper()
+        super(SettingsWrapper, self).__init__(monkeypatch, wrapper.wrapped)
+        super(SettingsWrapper, self).__setattr__(
+            'wrapper', wrapper)
+
+    def get_wrapper(self):
+        from django.test.utils import override_settings
+        wrapper = override_settings()
+        wrapper.enable()
+        return wrapper
+
+    def __delattr__(self, attr):
+        super(SettingsWrapper, self).__delattr__(attr)
+        if attr in self.wrapper.options:
+            del self.wrapper.options[attr]
+            self.wrapper.enable()
+
+    def __setattr__(self, attr, value):
+        super(SettingsWrapper, self).__setattr__(attr, value)
+        self.wrapper.options[attr] = value
+        self.wrapper.enable()
+
+    def finalize(self):
+        self.wrapper.disable()
+
+
+@pytest.yield_fixture()
+def settings(monkeypatch):
     """A Django settings object which restores changes after the testrun"""
     skip_if_no_django()
 
-    from django.conf import settings as django_settings
-
-    wrapper = SettingsWrapper(request.node, django_settings)
-    request.addfinalizer(wrapper._restore)
-    return wrapper
+    wrapper = SettingsWrapper(monkeypatch)
+    yield wrapper
+    wrapper.finalize()
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -83,6 +83,77 @@ class TestSettings:
         assert hasattr(settings, 'SECRET_KEY')
         assert hasattr(real_settings, 'SECRET_KEY')
 
+    def test_signals(self, settings):
+        result = []
+
+        def assert_signal(signal, sender, setting, value, enter):
+            result.append((setting, value, enter))
+
+        from django.test.signals import setting_changed
+        setting_changed.connect(assert_signal)
+
+        result = []
+        settings.SECRET_KEY = 'change 1'
+        settings.SECRET_KEY = 'change 2'
+        assert result == [
+            ('SECRET_KEY', 'change 1', True),
+            ('SECRET_KEY', 'change 2', True),
+        ]
+
+        result = []
+        settings.FOOBAR = 'abc123'
+        assert result == [
+            ('FOOBAR', 'abc123', True),
+        ]
+
+    def test_modification_signal(self, django_testdir):
+        django_testdir.create_test_module("""
+            import pytest
+
+            from django.conf import settings
+            from django.test.signals import setting_changed
+
+
+            @pytest.fixture(autouse=True, scope='session')
+            def settings_change_printer():
+                def receiver(sender, **kwargs):
+                    fmt_dict = {'actual_value': getattr(settings, kwargs['setting'],
+                                                        '<<does not exist>>')}
+                    fmt_dict.update(kwargs)
+
+                    print('Setting changed: '
+                          'enter=%(enter)s,setting=%(setting)s,'
+                          'value=%(value)s,actual_value=%(actual_value)s'
+                          % fmt_dict)
+
+                setting_changed.connect(receiver, weak=False)
+
+
+            def test_set(settings):
+                settings.SECRET_KEY = 'change 1'
+                settings.SECRET_KEY = 'change 2'
+
+
+            def test_set_non_existent(settings):
+                settings.FOOBAR = 'abc123'
+         """)
+
+        result = django_testdir.runpytest_subprocess('--tb=short', '-v', '-s')
+
+        # test_set
+        result.stdout.fnmatch_lines([
+            '*Setting changed: enter=True,setting=SECRET_KEY,value=change 1*',
+            '*Setting changed: enter=True,setting=SECRET_KEY,value=change 2*',
+            '*Setting changed: enter=False,setting=SECRET_KEY,value=change 1*',
+            '*Setting changed: enter=False,setting=SECRET_KEY,value=foobar*',
+        ])
+
+        result.stdout.fnmatch_lines([
+            '*Setting changed: enter=True,setting=FOOBAR,value=abc123*',
+            ('*Setting changed: enter=False,setting=FOOBAR,value=None,'
+             'actual_value=<<does not exist>>*'),
+        ])
+
 
 class TestLiveServer:
     def test_url(self, live_server):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -102,8 +102,9 @@ class TestSettings:
 
         result = []
         settings.FOOBAR = 'abc123'
-        assert result == [
+        assert sorted(result) == [
             ('FOOBAR', 'abc123', True),
+            ('SECRET_KEY', 'change 2', True),
         ]
 
     def test_modification_signal(self, django_testdir):
@@ -145,13 +146,11 @@ class TestSettings:
             '*Setting changed: enter=True,setting=SECRET_KEY,value=change 1*',
             '*Setting changed: enter=True,setting=SECRET_KEY,value=change 2*',
             '*Setting changed: enter=False,setting=SECRET_KEY,value=change 1*',
-            '*Setting changed: enter=False,setting=SECRET_KEY,value=foobar*',
         ])
 
         result.stdout.fnmatch_lines([
             '*Setting changed: enter=True,setting=FOOBAR,value=abc123*',
-            ('*Setting changed: enter=False,setting=FOOBAR,value=None,'
-             'actual_value=<<does not exist>>*'),
+            '*Setting changed: enter=False,setting=FOOBAR,value=abc123*',
         ])
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -104,7 +104,6 @@ class TestSettings:
         settings.FOOBAR = 'abc123'
         assert sorted(result) == [
             ('FOOBAR', 'abc123', True),
-            ('SECRET_KEY', 'change 2', True),
         ]
 
     def test_modification_signal(self, django_testdir):
@@ -146,11 +145,13 @@ class TestSettings:
             '*Setting changed: enter=True,setting=SECRET_KEY,value=change 1*',
             '*Setting changed: enter=True,setting=SECRET_KEY,value=change 2*',
             '*Setting changed: enter=False,setting=SECRET_KEY,value=change 1*',
+            '*Setting changed: enter=False,setting=SECRET_KEY,value=foobar*',
         ])
 
         result.stdout.fnmatch_lines([
             '*Setting changed: enter=True,setting=FOOBAR,value=abc123*',
-            '*Setting changed: enter=False,setting=FOOBAR,value=abc123*',
+            ('*Setting changed: enter=False,setting=FOOBAR,value=None,'
+             'actual_value=<<does not exist>>*'),
         ])
 
 


### PR DESCRIPTION
When changing/deleting a setting, the
django.test.signals.setting_changed fixture will be sent, just like
Django's override_settings decorator.

Refs #93, #46.

more and more apps are using this signal to clean their caches, so more and more settings can't be changed with this fixture
