### PR TITLE
Make help for --create-db more clear

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -43,7 +43,7 @@ def pytest_addoption(parser):
     group._addoption('--create-db',
                      action='store_true', dest='create_db', default=False,
                      help='Re-create the database, even if it exists. This '
-                          'option will be ignored if not --reuse-db is given.')
+                          'option will be ignored unless --reuse-db is given.')
     group._addoption('--ds',
                      action='store', type='string', dest='ds', default=None,
                      help='Set DJANGO_SETTINGS_MODULE.')


### PR DESCRIPTION
I thought it was a typo, but I now believe that --create-db does rely on --reuse-db. I don't understand why that would be the case, so maybe this isn't the correct fix.