### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,10 +9,10 @@ pytest-django allows you to test your Django project/applications with the
 `pytest testing tool <http://pytest.org/>`_.
 
 * `Quick start / tutorial
-  <http://pytest-django.readthedocs.org/en/latest/tutorial.html>`_
-* Full documentation: http://pytest-django.readthedocs.org/en/latest/
+  <https://pytest-django.readthedocs.io/en/latest/tutorial.html>`_
+* Full documentation: https://pytest-django.readthedocs.io/en/latest/
 * `Contribution docs
-  <http://pytest-django.readthedocs.org/en/latest/contributing.html>`_
+  <https://pytest-django.readthedocs.io/en/latest/contributing.html>`_
 * Version compatibility:
 
   * Django: 1.4-1.9 and latest master branch (compatible at the time of each release)

--- a/docs/managing_python_path.rst
+++ b/docs/managing_python_path.rst
@@ -59,7 +59,7 @@ content will get you started::
 This ``setup.py`` file is not sufficient to distribute your package to PyPI or
 more general packaging, but it should help you get started. Please refer to the
 `Python Packaging User Guide
-<http://python-packaging-user-guide.readthedocs.org/en/latest/tutorial.html#creating-your-own-project>`_
+<https://python-packaging-user-guide.readthedocs.io/en/latest/tutorial.html#creating-your-own-project>`_
 for more information on packaging Python applications.`
 
 To install the project afterwards::

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ DJANGO_SETTINGS_MODULE = pytest_django_test.settings_sqlite_file
 universal = 1
 
 [flake8]
-# Ref: http://flake8.readthedocs.org/en/latest/warnings.html#error-codes
+# Ref: https://flake8.readthedocs.io/en/latest/warnings.html#error-codes
 ignore = NONE
 # Default, if empty:
 # ignore = E123,E133,E226,E241,E242

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email='andreas@pelme.se',
     maintainer="Andreas Pelme",
     maintainer_email="andreas@pelme.se",
-    url='http://pytest-django.readthedocs.org/',
+    url='https://pytest-django.readthedocs.io/',
     license='BSD-3-Clause',
     packages=['pytest_django'],
     long_description=read('README.rst'),


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.