### PR TITLE
Option to use one database when xdist plugin is used

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -70,7 +70,7 @@ def _django_db_setup(request,
 def is_xdist_one_db_enabled(config):
     from django.conf import settings
     is_sqlite = (settings.DATABASES['default']['ENGINE'] == 'django.db.backends.sqlite3')
-    # can't use one sqlite3 db for distributed database because of lock
+    # can't use one sqlite3 db for distributed test run because of lock
     return config.getvalue('xdist_one_db') and not is_sqlite
 
 

--- a/tests/test_db_setup.py
+++ b/tests/test_db_setup.py
@@ -190,6 +190,32 @@ def test_xdist_with_reuse(django_testdir):
     result.stdout.fnmatch_lines(['*PASSED*test_d*'])
 
 
+def test_xdist_with_one_db_does_not_work_with_sqlite(django_testdir):
+    django_testdir.create_test_module('''
+        import pytest
+
+        from .app.models import Item
+
+        def _check(settings):
+            # Make sure that the database name looks correct
+            db_name = settings.DATABASES['default']['NAME']
+            assert db_name.endswith('_gw0')
+
+            assert Item.objects.count() == 0
+            Item.objects.create(name='foo')
+            assert Item.objects.count() == 1
+
+
+        @pytest.mark.django_db
+        def test_a(settings):
+            _check(settings)
+    ''')
+
+    result = django_testdir.runpytest_subprocess('-vv', '-n1', '-s', '--xdist-one-db')
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(['*PASSED*test_a*'])
+
+
 class TestSqliteWithXdist:
 
     pytestmark = skip_on_python32


### PR DESCRIPTION
this got stuck for some reason: https://github.com/pytest-dev/pytest-django/pull/98
