### PR TITLE
generate_configurations: remove UID / db creation from tox configs

### DIFF
--- a/generate_configurations.py
+++ b/generate_configurations.py
@@ -13,12 +13,15 @@ from textwrap import dedent
 TestEnvBase = namedtuple('TestEnvBase', ['python_version', 'pytest_version',
                                          'django_version', 'settings'])
 
+
 class TestEnv(TestEnvBase):
     def is_py2(self):
-        return self.python_version.startswith('python2') or self.python_version == 'pypy'
+        return (self.python_version.startswith('python2') or
+                self.python_version == 'pypy')
 
     def is_py3(self):
-        return self.python_version.startswith('python3') or self.python_version == 'pypy3'
+        return (self.python_version.startswith('python3') or
+                self.python_version == 'pypy3')
 
     def is_pypy(self):
         return self.python_version.startswith('pypy')
@@ -59,7 +62,7 @@ def is_valid_env(env):
         return False
 
     dj_version = tuple(int(x) if x != 'master' else math.inf
-                        for x in env.django_version.split('.'))
+                       for x in env.django_version.split('.'))
 
     if env.is_py3():
         # MySQL on Python 3 is not supported by Django
@@ -221,7 +224,7 @@ def make_travis_yml(envs):
 
           - pip install tox==2.3.1
         script: tox -e $TESTENV
-        """).strip("\n")
+        """).strip("\n")  # noqa
     testenvs = '\n'.join('  - TESTENV=%s' % testenv_name(env) for env in envs)
     checkenvs = '\n'.join('  - TESTENV=checkqa-%s' %
                           python for python in PYTHON_MAIN_VERSIONS)
@@ -247,7 +250,7 @@ def main():
     with open('.travis.yml', 'w+') as travis_yml_file:
         travis_yml_file.write(make_travis_yml(default_envs))
 
-    print ('tox.ini and .travis.yml has been generated!')
+    print('tox.ini and .travis.yml has been generated!')
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
                  'Programming Language :: Python :: 3.2',
                  'Programming Language :: Python :: 3.3',
                  'Programming Language :: Python :: 3.4',
-                ],
+                 ],
     # the following makes a plugin available to py.test
     entry_points={'pytest11': ['django = pytest_django.plugin']})

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,6 @@ commands =
 basepython = python2.7
 deps =
     flake8
-setenv =
-    UID = 1
 
 [testenv:checkqa-python3.3]
 commands =
@@ -23,8 +21,6 @@ commands =
 basepython = python3.3
 deps =
     flake8
-setenv =
-    UID = 2
 
 [testenv:checkqa-python3.4]
 commands =
@@ -33,8 +29,6 @@ commands =
 basepython = python3.4
 deps =
     flake8
-setenv =
-    UID = 3
 
 [testenv:checkqa-python3.5]
 commands =
@@ -43,8 +37,6 @@ commands =
 basepython = python3.5
 deps =
     flake8
-setenv =
-    UID = 4
 
 [testenv:checkqa-pypy]
 commands =
@@ -53,8 +45,6 @@ commands =
 basepython = pypy
 deps =
     flake8
-setenv =
-    UID = 5
 
 [testenv:checkqa-pypy3]
 commands =
@@ -63,8 +53,6 @@ commands =
 basepython = pypy3
 deps =
     flake8
-setenv =
-    UID = 6
 
 [testenv:python2.7-master-sqlite]
 commands =
@@ -77,7 +65,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 7
 
 
 [testenv:python2.7-master-sqlite_file]
@@ -91,12 +78,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 8
 
 
 [testenv:python2.7-master-mysql_myisam]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_9; create database pytest_django_9'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -107,12 +92,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 9
 
 
 [testenv:python2.7-master-mysql_innodb]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_10; create database pytest_django_10'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -123,12 +106,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 10
 
 
 [testenv:python2.7-master-postgres]
 commands =
-    sh -c "dropdb pytest_django_11; createdb pytest_django_11 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -139,7 +120,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 11
 
 
 [testenv:python2.7-1.7-sqlite]
@@ -153,7 +133,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 12
 
 
 [testenv:python2.7-1.7-sqlite_file]
@@ -167,12 +146,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 13
 
 
 [testenv:python2.7-1.7-mysql_myisam]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_14; create database pytest_django_14'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -183,12 +160,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 14
 
 
 [testenv:python2.7-1.7-mysql_innodb]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_15; create database pytest_django_15'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -199,12 +174,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 15
 
 
 [testenv:python2.7-1.7-postgres]
 commands =
-    sh -c "dropdb pytest_django_16; createdb pytest_django_16 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -215,7 +188,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 16
 
 
 [testenv:python2.7-1.8-sqlite]
@@ -229,7 +201,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 17
 
 
 [testenv:python2.7-1.8-sqlite_file]
@@ -243,12 +214,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 18
 
 
 [testenv:python2.7-1.8-mysql_myisam]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_19; create database pytest_django_19'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -259,12 +228,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 19
 
 
 [testenv:python2.7-1.8-mysql_innodb]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_20; create database pytest_django_20'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -275,12 +242,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 20
 
 
 [testenv:python2.7-1.8-postgres]
 commands =
-    sh -c "dropdb pytest_django_21; createdb pytest_django_21 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -291,7 +256,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 21
 
 
 [testenv:python2.7-1.9-sqlite]
@@ -305,7 +269,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 22
 
 
 [testenv:python2.7-1.9-sqlite_file]
@@ -319,12 +282,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 23
 
 
 [testenv:python2.7-1.9-mysql_myisam]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_24; create database pytest_django_24'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -335,12 +296,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 24
 
 
 [testenv:python2.7-1.9-mysql_innodb]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_25; create database pytest_django_25'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -351,12 +310,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 25
 
 
 [testenv:python2.7-1.9-postgres]
 commands =
-    sh -c "dropdb pytest_django_26; createdb pytest_django_26 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -367,7 +324,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 26
 
 
 [testenv:python2.7-1.10-sqlite]
@@ -381,7 +337,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 27
 
 
 [testenv:python2.7-1.10-sqlite_file]
@@ -395,12 +350,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 28
 
 
 [testenv:python2.7-1.10-mysql_myisam]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_29; create database pytest_django_29'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_myisam --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -411,12 +364,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 29
 
 
 [testenv:python2.7-1.10-mysql_innodb]
 commands =
-    sh -c "mysql -u root -e 'drop database if exists pytest_django_30; create database pytest_django_30'" || exit 0
     py.test --ds=pytest_django_test.settings_mysql_innodb --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -427,12 +378,10 @@ deps =
     mysql-python==1.2.5
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 30
 
 
 [testenv:python2.7-1.10-postgres]
 commands =
-    sh -c "dropdb pytest_django_31; createdb pytest_django_31 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python2.7
 deps =
@@ -443,7 +392,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 31
 
 
 [testenv:python3.3-1.7-sqlite]
@@ -457,7 +405,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 32
 
 
 [testenv:python3.3-1.7-sqlite_file]
@@ -471,12 +418,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 33
 
 
 [testenv:python3.3-1.7-postgres]
 commands =
-    sh -c "dropdb pytest_django_34; createdb pytest_django_34 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
@@ -487,7 +432,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 34
 
 
 [testenv:python3.3-1.8-sqlite]
@@ -501,7 +445,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 35
 
 
 [testenv:python3.3-1.8-sqlite_file]
@@ -515,12 +458,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 36
 
 
 [testenv:python3.3-1.8-postgres]
 commands =
-    sh -c "dropdb pytest_django_37; createdb pytest_django_37 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.3
 deps =
@@ -531,7 +472,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 37
 
 
 [testenv:python3.4-master-sqlite]
@@ -545,7 +485,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 38
 
 
 [testenv:python3.4-master-sqlite_file]
@@ -559,12 +498,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 39
 
 
 [testenv:python3.4-master-postgres]
 commands =
-    sh -c "dropdb pytest_django_40; createdb pytest_django_40 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
@@ -575,7 +512,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 40
 
 
 [testenv:python3.4-1.7-sqlite]
@@ -589,7 +525,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 41
 
 
 [testenv:python3.4-1.7-sqlite_file]
@@ -603,12 +538,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 42
 
 
 [testenv:python3.4-1.7-postgres]
 commands =
-    sh -c "dropdb pytest_django_43; createdb pytest_django_43 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
@@ -619,7 +552,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 43
 
 
 [testenv:python3.4-1.8-sqlite]
@@ -633,7 +565,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 44
 
 
 [testenv:python3.4-1.8-sqlite_file]
@@ -647,12 +578,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 45
 
 
 [testenv:python3.4-1.8-postgres]
 commands =
-    sh -c "dropdb pytest_django_46; createdb pytest_django_46 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
@@ -663,7 +592,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 46
 
 
 [testenv:python3.4-1.9-sqlite]
@@ -677,7 +605,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 47
 
 
 [testenv:python3.4-1.9-sqlite_file]
@@ -691,12 +618,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 48
 
 
 [testenv:python3.4-1.9-postgres]
 commands =
-    sh -c "dropdb pytest_django_49; createdb pytest_django_49 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
@@ -707,7 +632,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 49
 
 
 [testenv:python3.4-1.10-sqlite]
@@ -721,7 +645,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 50
 
 
 [testenv:python3.4-1.10-sqlite_file]
@@ -735,12 +658,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 51
 
 
 [testenv:python3.4-1.10-postgres]
 commands =
-    sh -c "dropdb pytest_django_52; createdb pytest_django_52 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.4
 deps =
@@ -751,7 +672,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 52
 
 
 [testenv:python3.5-master-sqlite]
@@ -765,7 +685,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 53
 
 
 [testenv:python3.5-master-sqlite_file]
@@ -779,12 +698,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 54
 
 
 [testenv:python3.5-master-postgres]
 commands =
-    sh -c "dropdb pytest_django_55; createdb pytest_django_55 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
@@ -795,7 +712,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 55
 
 
 [testenv:python3.5-1.8-sqlite]
@@ -809,7 +725,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 56
 
 
 [testenv:python3.5-1.8-sqlite_file]
@@ -823,12 +738,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 57
 
 
 [testenv:python3.5-1.8-postgres]
 commands =
-    sh -c "dropdb pytest_django_58; createdb pytest_django_58 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
@@ -839,7 +752,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 58
 
 
 [testenv:python3.5-1.9-sqlite]
@@ -853,7 +765,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 59
 
 
 [testenv:python3.5-1.9-sqlite_file]
@@ -867,12 +778,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 60
 
 
 [testenv:python3.5-1.9-postgres]
 commands =
-    sh -c "dropdb pytest_django_61; createdb pytest_django_61 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
@@ -883,7 +792,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 61
 
 
 [testenv:python3.5-1.10-sqlite]
@@ -897,7 +805,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 62
 
 
 [testenv:python3.5-1.10-sqlite_file]
@@ -911,12 +818,10 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 63
 
 
 [testenv:python3.5-1.10-postgres]
 commands =
-    sh -c "dropdb pytest_django_64; createdb pytest_django_64 || exit 0"
     py.test --ds=pytest_django_test.settings_postgres --strict -r fEsxXw {posargs:tests}
 basepython = python3.5
 deps =
@@ -927,7 +832,6 @@ deps =
     psycopg2==2.6.1
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 64
 
 
 [testenv:pypy-master-sqlite]
@@ -941,7 +845,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 65
 
 
 [testenv:pypy-master-sqlite_file]
@@ -955,7 +858,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 66
 
 
 [testenv:pypy-1.7-sqlite]
@@ -969,7 +871,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 67
 
 
 [testenv:pypy-1.7-sqlite_file]
@@ -983,7 +884,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 68
 
 
 [testenv:pypy-1.8-sqlite]
@@ -997,7 +897,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 69
 
 
 [testenv:pypy-1.8-sqlite_file]
@@ -1011,7 +910,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 70
 
 
 [testenv:pypy-1.9-sqlite]
@@ -1025,7 +923,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 71
 
 
 [testenv:pypy-1.9-sqlite_file]
@@ -1039,7 +936,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 72
 
 
 [testenv:pypy-1.10-sqlite]
@@ -1053,7 +949,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 73
 
 
 [testenv:pypy-1.10-sqlite_file]
@@ -1067,7 +962,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 74
 
 
 [testenv:pypy3-1.7-sqlite]
@@ -1081,7 +975,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 75
 
 
 [testenv:pypy3-1.7-sqlite_file]
@@ -1095,7 +988,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 76
 
 
 [testenv:pypy3-1.8-sqlite]
@@ -1109,7 +1001,6 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 77
 
 
 [testenv:pypy3-1.8-sqlite_file]
@@ -1123,4 +1014,3 @@ deps =
     django-configurations==1.0
 setenv =
      PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-     UID = 78


### PR DESCRIPTION
This is only required with Django versions before 1.7, and is meant to
make the diff of config updates simpler.