### PR TITLE
Remove the noop_transactions() helper.

### DIFF
--- a/pytest_django_test/db_helpers.py
+++ b/pytest_django_test/db_helpers.py
@@ -188,27 +188,3 @@ def mark_exists():
             conn.close()
 
     raise AssertionError('%s cannot be tested properly!' % get_db_engine())
-
-
-def noop_transactions():
-    """Test whether transactions are disabled.
-
-    Return True if transactions are disabled, False if they are
-    enabled.
-    """
-
-    # Newer versions of Django simply run standard tests in an atomic block.
-    if hasattr(connection, 'in_atomic_block'):
-        return connection.in_atomic_block
-    else:
-        with transaction.commit_manually():
-            Item.objects.create(name='transaction_noop_test')
-            transaction.rollback()
-
-        try:
-            item = Item.objects.get(name='transaction_noop_test')
-        except Item.DoesNotExist:
-            return False
-        else:
-            item.delete()
-            return True

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,7 +1,7 @@
 from __future__ import with_statement
 
 import pytest
-from django.db import connection, transaction
+from django.db import connection
 from django.test.testcases import connections_support_transactions
 
 from pytest_django_test.app.models import Item

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -14,7 +14,6 @@ from django.test.testcases import connections_support_transactions
 from pytest_django.lazy_django import get_django_version
 from pytest_django_test.app.models import Item
 from pytest_django_test.compat import force_text, HTTPError, urlopen
-from pytest_django_test.db_helpers import noop_transactions
 
 
 def test_client(client):
@@ -92,7 +91,7 @@ class TestLiveServer:
         if not connections_support_transactions():
             pytest.skip('transactions required for this test')
 
-        assert not noop_transactions()
+        assert not connection.in_atomic_block
 
     def test_db_changes_visibility(self, live_server):
         response_data = urlopen(live_server + '/item_count/').read()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -7,6 +7,8 @@ fixtures are tested in test_database.
 from __future__ import with_statement
 
 import pytest
+
+from django.db import connection
 from django.conf import settings as real_settings
 from django.test.client import Client, RequestFactory
 from django.test.testcases import connections_support_transactions


### PR DESCRIPTION
It is not needed anymore with newer Django versions.