### PR TITLE
Make it easy to run `flake8` locally without tox.

### DIFF
--- a/pytest_django_test/settings_mysql_innodb.py
+++ b/pytest_django_test/settings_mysql_innodb.py
@@ -3,7 +3,7 @@ from .settings_base import *  # noqa
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'pytest_django' + db_suffix,
+        'NAME': 'pytest_django' + db_suffix,  # noqa
         'HOST': 'localhost',
         'USER': 'root',
         'OPTIONS': {

--- a/pytest_django_test/settings_mysql_myisam.py
+++ b/pytest_django_test/settings_mysql_myisam.py
@@ -3,7 +3,7 @@ from pytest_django_test.settings_base import *  # noqa
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'pytest_django' + db_suffix,
+        'NAME': 'pytest_django' + db_suffix,  # noqa
         'HOST': 'localhost',
         'USER': 'root',
         'OPTIONS': {

--- a/pytest_django_test/settings_postgres.py
+++ b/pytest_django_test/settings_postgres.py
@@ -11,7 +11,7 @@ except ImportError:
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'pytest_django' + db_suffix,
+        'NAME': 'pytest_django' + db_suffix,  # noqa
         'HOST': 'localhost',
         'USER': '',
     },

--- a/pytest_django_test/settings_sqlite_file.py
+++ b/pytest_django_test/settings_sqlite_file.py
@@ -4,7 +4,7 @@ from pytest_django_test.settings_base import *  # noqa
 # tests (via setting TEST_NAME / TEST['NAME']).
 
 # The name as expected / used by Django/pytest_django (tests/db_helpers.py).
-db_name = 'DBNAME_pytest_django_db' + db_suffix
+db_name = 'DBNAME_pytest_django_db' + db_suffix  # noqa
 test_db_name = 'test_' + db_name + '_db_test'
 
 DATABASES = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest-xdist
 tox
 wheel
 twine
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ ignore = NONE
 # Default, if empty:
 # ignore = E123,E133,E226,E241,E242
 max-line-length = 99
+exclude = lib/,src/,docs/,bin/
 
 [isort]
 # NOTE: local imports are handled special (they do not get handled as "tests").

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ whitelist_externals =
 [testenv:checkqa-python2.7]
 commands =
     flake8 --version
-    flake8 --show-source --statistics pytest_django tests
+    flake8 --show-source --statistics
 basepython = python2.7
 deps =
     flake8
@@ -17,7 +17,7 @@ deps =
 [testenv:checkqa-python3.3]
 commands =
     flake8 --version
-    flake8 --show-source --statistics pytest_django tests
+    flake8 --show-source --statistics
 basepython = python3.3
 deps =
     flake8
@@ -25,7 +25,7 @@ deps =
 [testenv:checkqa-python3.4]
 commands =
     flake8 --version
-    flake8 --show-source --statistics pytest_django tests
+    flake8 --show-source --statistics
 basepython = python3.4
 deps =
     flake8
@@ -33,7 +33,7 @@ deps =
 [testenv:checkqa-python3.5]
 commands =
     flake8 --version
-    flake8 --show-source --statistics pytest_django tests
+    flake8 --show-source --statistics
 basepython = python3.5
 deps =
     flake8
@@ -41,7 +41,7 @@ deps =
 [testenv:checkqa-pypy]
 commands =
     flake8 --version
-    flake8 --show-source --statistics pytest_django tests
+    flake8 --show-source --statistics
 basepython = pypy
 deps =
     flake8
@@ -49,7 +49,7 @@ deps =
 [testenv:checkqa-pypy3]
 commands =
     flake8 --version
-    flake8 --show-source --statistics pytest_django tests
+    flake8 --show-source --statistics
 basepython = pypy3
 deps =
     flake8


### PR DESCRIPTION
Also, include pytest_django_test in the linting and fix existing linting
issues.