### PR TITLE
Use django.test.utils.{setup_databases,teardown_databases}

### DIFF
--- a/pytest_django/compat.py
+++ b/pytest_django/compat.py
@@ -1,0 +1,11 @@
+try:
+    # Django 1.11
+    from django.test.utils import setup_databases, teardown_databases  # noqa
+except ImportError:
+    # In Django prior to 1.11, teardown_databases is only available as a method on DiscoverRunner
+    from django.test.runner import setup_databases, DiscoverRunner as _DiscoverRunner  # noqa
+
+    def teardown_databases(db_cfg, verbosity):
+        (_DiscoverRunner(verbosity=verbosity,
+                         interactive=False)
+         .teardown_databases(db_cfg))

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -72,7 +72,7 @@ def django_db_setup(
     django_db_modify_db_settings,
 ):
     """Top level fixture to ensure test databases are available"""
-    from django.test.runner import setup_databases, DiscoverRunner
+    from .compat import setup_databases, teardown_databases
 
     setup_databases_args = {}
 
@@ -98,9 +98,10 @@ def django_db_setup(
 
     def teardown_database():
         with django_db_blocker:
-            (DiscoverRunner(verbosity=pytest.config.option.verbose,
-                            interactive=False)
-             .teardown_databases(db_cfg))
+            teardown_databases(
+                db_cfg,
+                verbosity=pytest.config.option.verbose,
+            )
 
     if not django_db_keepdb:
         request.addfinalizer(teardown_database)


### PR DESCRIPTION
This removes the ugly workaround of instantiating DiscoverRunner.

This fixes #376.