### PR TITLE
Avoid deprecation warnings on pytest 3.0

### DIFF
--- a/pytest_django/compat.py
+++ b/pytest_django/compat.py
@@ -22,4 +22,3 @@ def getfixturevalue(request, value):
         return request.getfixturevalue(value)
 
     return request.getfuncargvalue(value)
-

--- a/pytest_django/compat.py
+++ b/pytest_django/compat.py
@@ -18,8 +18,8 @@ except ImportError:
 
 
 def getfixturevalue(request, value):
-    try:
+    if hasattr(request, 'getfixturevalue'):
         return request.getfixturevalue(value)
-    except AttributeError:
-        return request.getfuncargvalue(value)
+
+    return request.getfuncargvalue(value)
 

--- a/pytest_django/compat.py
+++ b/pytest_django/compat.py
@@ -1,3 +1,5 @@
+# This file cannot be imported from until Django sets up
+
 try:
     # Django 1.11
     from django.test.utils import setup_databases, teardown_databases  # noqa
@@ -15,10 +17,3 @@ try:
 except ImportError:
     # Django 1.7.
     from django.db.backends import BaseDatabaseWrapper  # noqa
-
-
-def getfixturevalue(request, value):
-    if hasattr(request, 'getfixturevalue'):
-        return request.getfixturevalue(value)
-
-    return request.getfuncargvalue(value)

--- a/pytest_django/compat.py
+++ b/pytest_django/compat.py
@@ -15,3 +15,11 @@ try:
 except ImportError:
     # Django 1.7.
     from django.db.backends import BaseDatabaseWrapper  # noqa
+
+
+def getfixturevalue(request, value):
+    try:
+        return request.getfixturevalue(value)
+    except AttributeError:
+        return request.getfuncargvalue(value)
+

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -9,6 +9,7 @@ import pytest
 from . import live_server_helper
 
 from .django_compat import is_django_unittest
+from .pytest_compat import getfixturevalue
 
 from .lazy_django import get_django_version, skip_if_no_django
 
@@ -154,7 +155,6 @@ def db(request, django_db_setup, django_db_blocker):
     """
     if 'transactional_db' in request.funcargnames \
             or 'live_server' in request.funcargnames:
-        from .compat import getfixturevalue
         getfixturevalue(request, 'transactional_db')
     else:
         _django_db_fixture_helper(False, request, django_db_blocker)
@@ -323,5 +323,4 @@ def _live_server_helper(request):
     function-scoped.
     """
     if 'live_server' in request.funcargnames:
-        from .compat import getfixturevalue
         getfixturevalue(request, 'transactional_db')

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -8,6 +8,7 @@ import pytest
 
 from . import live_server_helper
 
+from .compat import getfixturevalue
 from .django_compat import is_django_unittest
 
 from .lazy_django import get_django_version, skip_if_no_django
@@ -154,12 +155,7 @@ def db(request, django_db_setup, django_db_blocker):
     """
     if 'transactional_db' in request.funcargnames \
             or 'live_server' in request.funcargnames:
-        try:
-            getfixturevalue = request.getfixturevalue
-        except AttributeError:
-            getfixturevalue = request.getfuncargvalue
-
-        getfixturevalue('transactional_db')
+        getfixturevalue(request, 'transactional_db')
     else:
         _django_db_fixture_helper(False, request, django_db_blocker)
 
@@ -327,9 +323,4 @@ def _live_server_helper(request):
     function-scoped.
     """
     if 'live_server' in request.funcargnames:
-        try:
-            getfixturevalue = request.getfixturevalue
-        except AttributeError:
-            getfixturevalue = request.getfuncargvalue
-
-        getfixturevalue('transactional_db')
+        getfixturevalue(request, 'transactional_db')

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -8,7 +8,6 @@ import pytest
 
 from . import live_server_helper
 
-from .compat import getfixturevalue
 from .django_compat import is_django_unittest
 
 from .lazy_django import get_django_version, skip_if_no_django
@@ -155,6 +154,7 @@ def db(request, django_db_setup, django_db_blocker):
     """
     if 'transactional_db' in request.funcargnames \
             or 'live_server' in request.funcargnames:
+        from .compat import getfixturevalue
         getfixturevalue(request, 'transactional_db')
     else:
         _django_db_fixture_helper(False, request, django_db_blocker)
@@ -323,4 +323,5 @@ def _live_server_helper(request):
     function-scoped.
     """
     if 'live_server' in request.funcargnames:
+        from .compat import getfixturevalue
         getfixturevalue(request, 'transactional_db')

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -154,7 +154,12 @@ def db(request, django_db_setup, django_db_blocker):
     """
     if 'transactional_db' in request.funcargnames \
             or 'live_server' in request.funcargnames:
-        request.getfuncargvalue('transactional_db')
+        try:
+            getfixturevalue = request.getfixturevalue
+        except AttributeError:
+            getfixturevalue = request.getfuncargvalue
+
+        getfixturevalue('transactional_db')
     else:
         _django_db_fixture_helper(False, request, django_db_blocker)
 
@@ -322,4 +327,9 @@ def _live_server_helper(request):
     function-scoped.
     """
     if 'live_server' in request.funcargnames:
-        request.getfuncargvalue('transactional_db')
+        try:
+            getfixturevalue = request.getfixturevalue
+        except AttributeError:
+            getfixturevalue = request.getfuncargvalue
+
+        getfixturevalue('transactional_db')

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -369,18 +369,29 @@ def _django_db_marker(request):
     marker = request.keywords.get('django_db', None)
     if marker:
         validate_django_db(marker)
+
+        try:
+            getfixturevalue = request.getfixturevalue
+        except AttributeError:
+            getfixturevalue = request.getfuncargvalue
+
         if marker.transaction:
-            request.getfuncargvalue('transactional_db')
+            getfixturevalue('transactional_db')
         else:
-            request.getfuncargvalue('db')
+            getfixturevalue('db')
 
 
 @pytest.fixture(autouse=True, scope='class')
 def _django_setup_unittest(request, django_db_blocker):
     """Setup a django unittest, internal to pytest-django."""
     if django_settings_is_configured() and is_django_unittest(request):
-        request.getfuncargvalue('django_test_environment')
-        request.getfuncargvalue('django_db_setup')
+        try:
+            getfixturevalue = request.getfixturevalue
+        except AttributeError:
+            getfixturevalue = request.getfuncargvalue
+
+        getfixturevalue('django_test_environment')
+        getfixturevalue('django_db_setup')
 
         django_db_blocker.unblock()
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -380,9 +380,15 @@ def _django_db_marker(request):
 def _django_setup_unittest(request, django_db_blocker):
     """Setup a django unittest, internal to pytest-django."""
     if django_settings_is_configured() and is_django_unittest(request):
-        from .compat import getfixturevalue
-        getfixturevalue(request, 'django_test_environment')
-        getfixturevalue(request, 'django_db_setup')
+        # Cannot use pytest_django.compat.getfixturevalue as it would
+        # pull in Django deps too early
+        try:
+            getfixturevalue = request.getfixturevalue
+        except AttributeError:
+            getfixturevalue = request.getfuncargvalue
+
+        getfixturevalue('django_test_environment')
+        getfixturevalue('django_db_setup')
 
         django_db_blocker.unblock()
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -14,7 +14,6 @@ import types
 import py
 import pytest
 
-from .compat import getfixturevalue
 from .django_compat import is_django_unittest  # noqa
 from .fixtures import django_db_setup  # noqa
 from .fixtures import django_db_use_migrations  # noqa
@@ -370,6 +369,7 @@ def _django_db_marker(request):
     marker = request.keywords.get('django_db', None)
     if marker:
         validate_django_db(marker)
+        from .compat import getfixturevalue
         if marker.transaction:
             getfixturevalue(request, 'transactional_db')
         else:
@@ -380,6 +380,7 @@ def _django_db_marker(request):
 def _django_setup_unittest(request, django_db_blocker):
     """Setup a django unittest, internal to pytest-django."""
     if django_settings_is_configured() and is_django_unittest(request):
+        from .compat import getfixturevalue
         getfixturevalue(request, 'django_test_environment')
         getfixturevalue(request, 'django_db_setup')
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -31,6 +31,7 @@ from .fixtures import live_server  # noqa
 from .fixtures import rf  # noqa
 from .fixtures import settings  # noqa
 from .fixtures import transactional_db  # noqa
+from .pytest_compat import getfixturevalue
 
 from .lazy_django import (django_settings_is_configured,
                           get_django_version, skip_if_no_django)
@@ -369,7 +370,6 @@ def _django_db_marker(request):
     marker = request.keywords.get('django_db', None)
     if marker:
         validate_django_db(marker)
-        from .compat import getfixturevalue
         if marker.transaction:
             getfixturevalue(request, 'transactional_db')
         else:
@@ -380,15 +380,8 @@ def _django_db_marker(request):
 def _django_setup_unittest(request, django_db_blocker):
     """Setup a django unittest, internal to pytest-django."""
     if django_settings_is_configured() and is_django_unittest(request):
-        # Cannot use pytest_django.compat.getfixturevalue as it would
-        # pull in Django deps too early
-        try:
-            getfixturevalue = request.getfixturevalue
-        except AttributeError:
-            getfixturevalue = request.getfuncargvalue
-
-        getfixturevalue('django_test_environment')
-        getfixturevalue('django_db_setup')
+        getfixturevalue(request, 'django_test_environment')
+        getfixturevalue(request, 'django_db_setup')
 
         django_db_blocker.unblock()
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -14,6 +14,7 @@ import types
 import py
 import pytest
 
+from .compat import getfixturevalue
 from .django_compat import is_django_unittest  # noqa
 from .fixtures import django_db_setup  # noqa
 from .fixtures import django_db_use_migrations  # noqa
@@ -369,29 +370,18 @@ def _django_db_marker(request):
     marker = request.keywords.get('django_db', None)
     if marker:
         validate_django_db(marker)
-
-        try:
-            getfixturevalue = request.getfixturevalue
-        except AttributeError:
-            getfixturevalue = request.getfuncargvalue
-
         if marker.transaction:
-            getfixturevalue('transactional_db')
+            getfixturevalue(request, 'transactional_db')
         else:
-            getfixturevalue('db')
+            getfixturevalue(request, 'db')
 
 
 @pytest.fixture(autouse=True, scope='class')
 def _django_setup_unittest(request, django_db_blocker):
     """Setup a django unittest, internal to pytest-django."""
     if django_settings_is_configured() and is_django_unittest(request):
-        try:
-            getfixturevalue = request.getfixturevalue
-        except AttributeError:
-            getfixturevalue = request.getfuncargvalue
-
-        getfixturevalue('django_test_environment')
-        getfixturevalue('django_db_setup')
+        getfixturevalue(request, 'django_test_environment')
+        getfixturevalue(request, 'django_db_setup')
 
         django_db_blocker.unblock()
 

--- a/pytest_django/pytest_compat.py
+++ b/pytest_django/pytest_compat.py
@@ -1,0 +1,5 @@
+def getfixturevalue(request, value):
+    if hasattr(request, 'getfixturevalue'):
+        return request.getfixturevalue(value)
+
+    return request.getfuncargvalue(value)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,6 +4,7 @@ import pytest
 from django.db import connection
 from django.test.testcases import connections_support_transactions
 
+from pytest_django.pytest_compat import getfixturevalue
 from pytest_django_test.app.models import Item
 
 
@@ -32,7 +33,6 @@ class TestDatabaseFixtures:
 
     @pytest.fixture(params=['db', 'transactional_db'])
     def both_dbs(self, request):
-        from pytest_django.compat import getfixturevalue
         if request.param == 'transactional_db':
             return getfixturevalue(request, 'transactional_db')
         elif request.param == 'db':

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -32,10 +32,15 @@ class TestDatabaseFixtures:
 
     @pytest.fixture(params=['db', 'transactional_db'])
     def both_dbs(self, request):
+        try:
+            getfixturevalue = request.getfixturevalue
+        except AttributeError:
+            getfixturevalue = request.getfuncargvalue
+
         if request.param == 'transactional_db':
-            return request.getfuncargvalue('transactional_db')
+            return getfixturevalue('transactional_db')
         elif request.param == 'db':
-            return request.getfuncargvalue('db')
+            return getfixturevalue('db')
 
     def test_access(self, both_dbs):
         Item.objects.create(name='spam')

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,7 +4,6 @@ import pytest
 from django.db import connection
 from django.test.testcases import connections_support_transactions
 
-from pytest_django.compat import getfixturevalue
 from pytest_django_test.app.models import Item
 
 
@@ -33,6 +32,7 @@ class TestDatabaseFixtures:
 
     @pytest.fixture(params=['db', 'transactional_db'])
     def both_dbs(self, request):
+        from pytest_django.compat import getfixturevalue
         if request.param == 'transactional_db':
             return getfixturevalue(request, 'transactional_db')
         elif request.param == 'db':

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,6 +4,7 @@ import pytest
 from django.db import connection
 from django.test.testcases import connections_support_transactions
 
+from pytest_django.compat import getfixturevalue
 from pytest_django_test.app.models import Item
 
 
@@ -32,15 +33,10 @@ class TestDatabaseFixtures:
 
     @pytest.fixture(params=['db', 'transactional_db'])
     def both_dbs(self, request):
-        try:
-            getfixturevalue = request.getfixturevalue
-        except AttributeError:
-            getfixturevalue = request.getfuncargvalue
-
         if request.param == 'transactional_db':
-            return getfixturevalue('transactional_db')
+            return getfixturevalue(request, 'transactional_db')
         elif request.param == 'db':
-            return getfixturevalue('db')
+            return getfixturevalue(request, 'db')
 
     def test_access(self, both_dbs):
         Item.objects.create(name='spam')


### PR DESCRIPTION
- Use getfixturevalue instead of getfuncargvalue if it exists
