### PR TITLE
Use Django override_settings for settings fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ _build
 .Python
 .eggs
 *.egg
+
+#py3 pyenv
+pyvenv.cfg
+lib64
+pip-selfcheck.json


### PR DESCRIPTION
This PR uses Django override_settings for the settings fixture.

The PR is mostly based on the work of PR [#141](https://github.com/pytest-dev/pytest-django/pull/324) and more recently PR [#324](https://github.com/pytest-dev/pytest-django/pull/324).

The latter attempted to use a different mechanism, but as discussed,
it's better to use the API provided by Django to ensure future
compatibility.
