### PR TITLE
_django_clear_outbox should clear mail.outbox instead of creating new list

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -399,7 +399,7 @@ def _django_setup_unittest(request, django_db_blocker):
 
 
 @pytest.fixture(autouse=True, scope='function')
-def _django_clear_outbox():
+def _django_clear_outbox(django_test_environment):
     """Clear the django outbox, internal to pytest-django."""
     if django_settings_is_configured():
         from django.core import mail

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -403,7 +403,7 @@ def _django_clear_outbox():
     """Clear the django outbox, internal to pytest-django."""
     if django_settings_is_configured():
         from django.core import mail
-        mail.outbox = []
+        del mail.outbox[:]
 
 
 @pytest.fixture(autouse=True, scope='function')


### PR DESCRIPTION
The _django_clear_outbox fixture creates a new list, not clearing the existing mailbox. This can cause problems as fixture execution order cannot be guaranteed, and there might be fixtures (in my case an mailoutbox fixture) that just contains a reference to mail.outbox to be able to check what emails was sent out by the system... however, tests fails randomly as sometimes my own fixture actually gets reference to an old mailbox, not the newly created one...
