### PR TITLE
Adding mailoutbox fixture, and removing internal _django_clear_outbox

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,8 @@ Compatibility
 * IMPORTANT: the internal autouse fixture _django_clear_outbox has been
   removed. If you have relied on this to get an empty outbox for your
   test, you should change tests to use the ``mailoutbox`` fixture instead.
-  See documentation of ``mailoutbox`` fixture for usage.
+  See documentation of ``mailoutbox`` fixture for usage. If you try to
+  access mail.outbox directly, AssertionError will be raised.
 
 3.0.0
 -----

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+3.1.0
+-----
+
+Features
+^^^^^^^^
+* Added new function scoped fixture ``mailoutbox`` that gives access to
+  djangos ``mail.outbox``. The will clean/empty the ``mail.outbox`` to
+  assure that no old mails are still in the outbox.
+
+Compatibility
+^^^^^^^^^^^^^
+* IMPORTANT: the internal autouse fixture _django_clear_outbox has been
+  removed. If you have relied on this to get an empty outbox for your
+  test, you should change tests to use the ``mailoutbox`` fixture instead.
+  See documentation of ``mailoutbox`` fixture for usage.
+
 3.0.0
 -----
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -217,3 +217,25 @@ Example
     def test_with_specific_settings(settings):
         settings.USE_TZ = True
         assert settings.USE_TZ
+
+``mailoutbox``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A clean mail outbox where django emails are being sent.
+
+Example
+"""""""
+
+::
+
+    from django.core import mail
+
+    def test_mail(mailoutbox):
+        mail.send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
+        assert len(mailoutbox) == 1
+        m = mailoutbox[0]
+        assert m.subject == 'subject'
+        assert m.body == 'body'
+        assert m.from_email == 'from@example.com'
+        assert list(m.to) == ['to@example.com']
+

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -402,7 +402,7 @@ def _django_setup_unittest(request, django_db_blocker):
 class _DirectMailboxAccessProtector(list):
 
     def _raise_assertion(*args, **kwargs):
-        raise AssertionError('Use the mailoutbox fixture')
+        raise AssertionError('To access mail.outbox, use the mailoutbox fixture.')
 
     __len__ = __getitem__ = __nonzero__ = __bool__ = _raise_assertion
 
@@ -424,7 +424,7 @@ def mailoutbox(_error_on_direct_mail_outbox_access):
     from django.core import mail
 
     _old_mailbox = getattr(mail, 'outbox', None)
-    outbox = []
+    outbox = list()
     setattr(mail, 'outbox', outbox)
 
     yield outbox

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -407,10 +407,6 @@ class _DirectMailboxAccessProtector(list):
     __len__ = __getitem__ = __nonzero__ = __bool__ = _raise_assertion
 
 
-# def mailoutbox_setup_and_teardown(outbox_type):
-#
-
-
 @pytest.yield_fixture(autouse=True)
 def _error_on_direct_mail_outbox_access():
     if not django_settings_is_configured():

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -407,13 +407,27 @@ class _DirectMailboxAccessProtector(list):
     __len__ = __getitem__ = __nonzero__ = __bool__ = _raise_assertion
 
 
+# def mailoutbox_setup_and_teardown(outbox_type):
+#
+
+
 @pytest.yield_fixture(autouse=True)
 def _error_on_direct_mail_outbox_access():
+    if not django_settings_is_configured():
+        return
+
     from django.core import mail
-    old = mail.outbox
-    mail.outbox = _DirectMailboxAccessProtector()
-    yield
-    mail.outbox = old
+
+    _old_mailbox = getattr(mail, 'outbox', None)
+    outbox = _DirectMailboxAccessProtector()
+    setattr(mail, 'outbox', outbox)
+
+    yield outbox
+
+    if _old_mailbox is not None:
+        setattr(mail, 'outbox', _old_mailbox)
+    else:
+        delattr(mail, 'outbox')
 
 
 @pytest.yield_fixture(scope='function')

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -407,42 +407,28 @@ class _DirectMailboxAccessProtector(list):
     __len__ = __getitem__ = __nonzero__ = __bool__ = _raise_assertion
 
 
-@pytest.yield_fixture(autouse=True)
-def _error_on_direct_mail_outbox_access():
+@pytest.fixture(autouse=True)
+def _error_on_direct_mail_outbox_access(monkeypatch):
     if not django_settings_is_configured():
         return
 
     from django.core import mail
 
-    _old_mailbox = getattr(mail, 'outbox', None)
     outbox = _DirectMailboxAccessProtector()
-    setattr(mail, 'outbox', outbox)
-
-    yield outbox
-
-    if _old_mailbox is not None:
-        setattr(mail, 'outbox', _old_mailbox)
-    else:
-        delattr(mail, 'outbox')
+    monkeypatch.setattr(mail, 'outbox', outbox)
+    return outbox
 
 
-@pytest.yield_fixture(scope='function')
-def mailoutbox(_error_on_direct_mail_outbox_access):
+@pytest.fixture(scope='function')
+def mailoutbox(monkeypatch, _error_on_direct_mail_outbox_access):
     if not django_settings_is_configured():
         return
 
     from django.core import mail
 
-    _old_mailbox = getattr(mail, 'outbox', None)
     outbox = list()
-    setattr(mail, 'outbox', outbox)
-
-    yield outbox
-
-    if _old_mailbox is not None:
-        setattr(mail, 'outbox', _old_mailbox)
-    else:
-        delattr(mail, 'outbox')
+    monkeypatch.setattr(mail, 'outbox', outbox)
+    return outbox
 
 
 @pytest.fixture(autouse=True, scope='function')

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -34,10 +34,16 @@ def test_direct_mailbox_proection_should_not_break_sending_mail():
 
 class TestDirectAccessWorksForDjangoTestCase(TestCase):
 
-    def test_one(self):
+    def _do_test(self):
         assert len(mail.outbox) == 0
         mail.send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
         assert len(mail.outbox) == 1
+
+    def test_one(self):
+        self._do_test()
+
+    def test_two(self):
+        self._do_test()
 
 
 @pytest.mark.django_project(extra_settings="""

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -15,20 +15,13 @@ from pytest_django_test.app.models import Item
 # to do it.
 
 
-def test_mail(mailoutbox):
-    assert mailoutbox is mail.outbox  # check that mail.outbox and fixture value is same object
-    assert len(mailoutbox) == 0
+def test_direct_mailbox_access_not_allowed():
+    with pytest.raises(AssertionError):
+        len(mail.outbox)
+
+
+def test_direct_mailbox_proection_should_not_break_sending_mail():
     mail.send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
-    assert len(mailoutbox) == 1
-    m = mailoutbox[0]
-    assert m.subject == 'subject'
-    assert m.body == 'body'
-    assert m.from_email == 'from@example.com'
-    assert list(m.to) == ['to@example.com']
-
-
-def test_mail_again(mailoutbox):
-    test_mail(mailoutbox)
 
 
 @pytest.mark.django_project(extra_settings="""

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -15,19 +15,20 @@ from pytest_django_test.app.models import Item
 # to do it.
 
 
-def test_mail():
-    assert len(mail.outbox) == 0
+def test_mail(mailoutbox):
+    assert mailoutbox is mail.outbox  # check that mail.outbox and the yielded value from the fixture is same object
+    assert len(mailoutbox) == 0
     mail.send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
-    assert len(mail.outbox) == 1
-    m = mail.outbox[0]
+    assert len(mailoutbox) == 1
+    m = mailoutbox[0]
     assert m.subject == 'subject'
     assert m.body == 'body'
     assert m.from_email == 'from@example.com'
     assert list(m.to) == ['to@example.com']
 
 
-def test_mail_again():
-    test_mail()
+def test_mail_again(mailoutbox):
+    test_mail(mailoutbox)
 
 
 @pytest.mark.django_project(extra_settings="""

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -16,7 +16,7 @@ from pytest_django_test.app.models import Item
 
 
 def test_mail(mailoutbox):
-    assert mailoutbox is mail.outbox  # check that mail.outbox and the yielded value from the fixture is same object
+    assert mailoutbox is mail.outbox  # check that mail.outbox and fixture value is same object
     assert len(mailoutbox) == 0
     mail.send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
     assert len(mailoutbox) == 1

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -5,6 +5,7 @@ import os
 import pytest
 from django.core import mail
 from django.db import connection
+from django.test import TestCase
 
 from pytest_django_test.app.models import Item
 
@@ -19,9 +20,24 @@ def test_direct_mailbox_access_not_allowed():
     with pytest.raises(AssertionError):
         len(mail.outbox)
 
+    with pytest.raises(AssertionError):
+        mail.outbox[0]
+
+    with pytest.raises(AssertionError):
+        if mail.outbox:
+            pass
+
 
 def test_direct_mailbox_proection_should_not_break_sending_mail():
     mail.send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
+
+
+class TestDirectAccessWorksForDjangoTestCase(TestCase):
+
+    def test_one(self):
+        assert len(mail.outbox) == 0
+        mail.send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
+        assert len(mail.outbox) == 1
 
 
 @pytest.mark.django_project(extra_settings="""

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -10,6 +10,7 @@ import pytest
 
 from django.db import connection
 from django.conf import settings as real_settings
+from django.core import mail
 from django.test.client import Client, RequestFactory
 from django.test.testcases import connections_support_transactions
 from django.utils.encoding import force_text
@@ -403,3 +404,19 @@ class Test_django_db_blocker:
     def test_unblock_with_block(self, django_db_blocker):
         with django_db_blocker.unblock():
             Item.objects.exists()
+
+
+def test_mail(mailoutbox):
+    assert mailoutbox is mail.outbox  # check that mail.outbox and fixture value is same object
+    assert len(mailoutbox) == 0
+    mail.send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
+    assert len(mailoutbox) == 1
+    m = mailoutbox[0]
+    assert m.subject == 'subject'
+    assert m.body == 'body'
+    assert m.from_email == 'from@example.com'
+    assert list(m.to) == ['to@example.com']
+
+
+def test_mail_again(mailoutbox):
+    test_mail(mailoutbox)


### PR DESCRIPTION
pytest-django doesn't provide any mechanism to get the mail outbox, however it is clearing the mailbox, that effects external fixtures that might want to interact with the mail.outbox. This fixture stores previous outbox (if any), creates a new list for usage in fixture, and then restores the state to what it was previously...

This PR is initiated to add a mailoutbox fixture, and if interested of getting this released, I would enhance it with documentation and possible tests...

PR #407 would not be needed if this is chosen as the path to go...
