### PR TITLE
in django >= 1.9 one can set module value to None in settings.MIGRATION_MODULES to not run

### DIFF
--- a/pytest_django/migrations.py
+++ b/pytest_django/migrations.py
@@ -1,8 +1,17 @@
 # code snippet copied from https://gist.github.com/NotSqrt/5f3c76cd15e40ef62d09
+from pytest_django.lazy_django import get_django_version
+
+
 class DisableMigrations(object):
+
+    def __init__(self):
+        self._django_version = get_django_version()
 
     def __contains__(self, item):
         return True
 
     def __getitem__(self, item):
-        return "notmigrations"
+        if self._django_version >= (1, 9):
+            return None
+        else:
+            return 'notmigrations'


### PR DESCRIPTION
Closes #417 