### PR TITLE
Expose fixtures to change Django's {Transaction,}TestCase

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -31,6 +31,8 @@ from .fixtures import live_server  # noqa
 from .fixtures import rf  # noqa
 from .fixtures import settings  # noqa
 from .fixtures import transactional_db  # noqa
+from .fixtures import django_db_testcase  # noqa
+from .fixtures import django_transactional_db_testcase  # noqa
 from .pytest_compat import getfixturevalue
 
 from .lazy_django import (django_settings_is_configured,


### PR DESCRIPTION
This adds `django_db_testcase` and `django_transactional_db_testcase`,
which allows to override them to e.g. enable the `multi_db` feature:

```
@pytest.fixture
def django_db_testcase(django_db_testcase):
    django_db_testcase.multi_db = True
    return django_db_testcase
```

Ref: https://github.com/pytest-dev/pytest-django/pull/397

TODO:
  - [ ] doc
- [ ] test(s) - not sure what should be tested here?  Maybe the `multi_db` feature (which requires to setup multiple DBs though)
