### PR TITLE
Fixed admin_user fixture for custom user model

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -212,7 +212,7 @@ def admin_user(db, django_user_model, django_username_field):
         user = UserModel._default_manager.get(**{username_field: 'admin'})
     except UserModel.DoesNotExist:
         extra_fields = {}
-        if username_field != 'username' and username_filed != 'email':
+        if username_field != 'username' and username_field != 'email':
             extra_fields[username_field] = 'admin'
         user = UserModel._default_manager.create_superuser(
             'admin', 'admin@example.com', 'password', **extra_fields)

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -212,7 +212,7 @@ def admin_user(db, django_user_model, django_username_field):
         user = UserModel._default_manager.get(**{username_field: 'admin'})
     except UserModel.DoesNotExist:
         extra_fields = {}
-        if username_field != 'username':
+        if username_field != 'username' and username_filed != 'email':
             extra_fields[username_field] = 'admin'
         user = UserModel._default_manager.create_superuser(
             'admin', 'admin@example.com', 'password', **extra_fields)


### PR DESCRIPTION
When custom user model had 'email' field set as username filed the fixture was resulting in Error `TypeError: create_superuser() got multiple values for argument 'email'`. Additional checking if `username_field` is not equal to 'email' fixed it.