### PR TITLE
Pimp up the docs! (use same theme as pytest)

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -1,0 +1,5 @@
+<h3>About pytest-django</h3>
+<p>
+  pytest-django is a plugin for <a href="http://pytest.org/">pytest</a>.
+  Better testing for your <a href="https://www.djangoproject.com/">Django</a> project!
+</p>

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -1,4 +1,4 @@
-<h3>About pytest-django</h3>
+<h3>About</h3>
 <p>
   pytest-django is a plugin for <a href="http://pytest.org/">pytest</a>.
   Better testing for your <a href="https://www.djangoproject.com/">Django</a> project!

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ Bug fixes
 * Auto clearing of ``mail.outbox`` has been re-introduced to not break
   functionality in 3.x.x release. This means that Compatibility issues
   mentioned in the 3.1.0 release are no longer present. Related issue:
-  _`pytest-django issue <https://github.com/pytest-dev/pytest-django/issues/433>`
+  `pytest-django issue <https://github.com/pytest-dev/pytest-django/issues/433>`__
 
 3.1.1
 -----
@@ -20,8 +20,9 @@ Bug fixes
 
 * Workaround `--pdb` interaction with Django TestCase. The issue is caused by
   Django TestCase not implementing TestCase.debug() properly but was brought to
-  attention with recent changes in pytest 3.0.2. Related issues: `pytest issue <https://github.com/pytest-dev/pytest/issues/1977>`_, 
-  `Django issue <https://code.djangoproject.com/ticket/27391>`_.
+  attention with recent changes in pytest 3.0.2. Related issues:
+  `pytest issue <https://github.com/pytest-dev/pytest/issues/1977>`__,
+  `Django issue <https://code.djangoproject.com/ticket/27391>`__
 
 3.1.0
 -----
@@ -59,7 +60,7 @@ Bug fixes
 
 * Fix error when Django happens to be imported before pytest-django runs.
   Thanks to Will Harris for `the bug report
-  <https://github.com/pytest-dev/pytest-django/issues/289>`_.
+  <https://github.com/pytest-dev/pytest-django/issues/289>`__.
 
 Features
 ^^^^^^^^
@@ -110,7 +111,7 @@ Bug fixes
 
 * Fix regression introduced in 2.9.0 that caused TestCase subclasses with
   mixins to cause errors. Thanks MikeVL for `the bug report
-  <https://github.com/pytest-dev/pytest-django/issues/280>`_.
+  <https://github.com/pytest-dev/pytest-django/issues/280>`__.
 
 
 2.9.0
@@ -130,11 +131,12 @@ Bug fixes
 * Ensure urlconf is properly reset when using @pytest.mark.urls. Thanks to
   Sarah Bird, David Szotten, Daniel Hahler and Yannick PÉROUX for patch and
   discussions. Fixes `issue #183
-  <https://github.com/pytest-dev/pytest-django/issues/183>`_.
+  <https://github.com/pytest-dev/pytest-django/issues/183>`__.
 
 * Call ``setUpClass()`` in Django ``TestCase`` properly when test class is
   inherited multiple places. Thanks to Benedikt Forchhammer for report and
-  initial test case. Fixes `issue #265 <https://github.com/pytest-dev/pytest-django/issues/265>`_.
+  initial test case. Fixes `issue #265
+  <https://github.com/pytest-dev/pytest-django/issues/265>`__.
 
 Compatibility
 ^^^^^^^^^^^^^
@@ -145,7 +147,7 @@ Compatibility
   instead. If you previously relied on overriding the environment variable,
   you can instead specify ``addopts = --ds=yourtestsettings`` in the ini-file
   which will use the test settings. See `PR #199
-  <https://github.com/pytest-dev/pytest-django/pull/199>`_.
+  <https://github.com/pytest-dev/pytest-django/pull/199>`__.
 
 * Support for Django 1.9.
 
@@ -186,7 +188,9 @@ Features
 * Automatic discovery of Django projects to make it easier for new users. This
   change is slightly backward incompatible, if you encounter problems with it,
   the old behaviour can be restored by adding this to ``pytest.ini``,
-  ``setup.cfg`` or ``tox.ini``::
+  ``setup.cfg`` or ``tox.ini``:
+
+  .. code-block:: ini
 
     [pytest]
     django_find_project = false
@@ -366,7 +370,7 @@ way for easier additions of new and exciting features in the future!
 1.3
 ---
 * Added ``--reuse-db`` and ``--create-db`` to allow database re-use. Many
-  thanks to `django-nose <https://github.com/jbalogh/django-nose>`_ for
+  thanks to `django-nose <https://github.com/jbalogh/django-nose>`__ for
   code and inspiration for this feature.
 
 1.2.2
@@ -389,7 +393,8 @@ way for easier additions of new and exciting features in the future!
 1.1
 ---
 
-* The initial release of this fork from `Ben Firshman original project <http://github.com/bfirsh/pytest_django>`_
+* The initial release of this fork from `Ben Firshman original project
+  <http://github.com/bfirsh/pytest_django>`__
 * Added documentation
 * Uploaded to PyPI for easy installation
 * Added the ``transaction_test_case`` decorator for tests that needs real transactions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,9 +33,25 @@ copyright = u'%d, Andreas Pelme and contributors' % datetime.date.today().year
 exclude_patterns = ['_build']
 
 pygments_style = 'sphinx'
-html_theme = 'default'
-html_style = 'rtd.css'
-RTD_NEW_THEME = True
+html_theme = 'flask'
+html_theme_options = {
+    # 'index_logo': '',
+    'github_fork': 'pytest-dev/pytest-django',
+}
+html_sidebars = {
+    'index': [
+        'sidebarintro.html',
+        'globaltoc.html',
+        'searchbox.html'
+    ],
+    '**': [
+        'globaltoc.html',
+        'relations.html',
+        'searchbox.html'
+    ]
+}
+# html_style = 'rtd.css'
+# RTD_NEW_THEME = True
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
The current docs use the default theme, which is a bit old-fashioned. This PR makes our docs use the same Sphinx theme [as the pytest project](https://github.com/pytest-dev/pytest/blob/master/doc/en/conf.py#L108-L113).

- Use Flask theme** for docs (same as pytest project)
- Use anonymous links in changelog to avoid link name clashes

** Flask is an [Alabaster theme](https://alabaster.readthedocs.io/en/latest/) clone.

Note
-----

- The Flask theme **requires** installing [Flask-Sphinx-Themes](https://github.com/pallets/flask-sphinx-themes) via `pip install Flask-Sphinx-Themes` (I've found no place for that in the `Makefile` or `../requirements.txt`) -- _should be added!_
- `pygments_style` is overridden [despite related instruction](https://github.com/pallets/flask-sphinx-themes#pygments-style) in the theme docs to match the code block coloring of the pytest docs.
- `make html` needs to run twice in order to resolve references across the documents.
- A **logo** would be nice! pytest has it, we don't.  :cry: :disappointed: 