### PR TITLE
Fix building the docs on RTD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tox
 wheel
 twine
 flake8
+Flask-Sphinx-Themes


### PR DESCRIPTION
- Add Flask-Sphinx-Themes to requirements for building the docs

Fixes #449.

Side Note
----------

I feel it's a bit odd to have a `requirements.txt` file in the root folder, which is - kind of - "pulled in by magic" (or by convention) by ReadTheDocs.

Isn't `requirements.txt`, when it exists in a package project's root folder, either referenced by `setup.py` for installation or expected to be used manually for installation of the package or project?

It's not all straight-forward. Also, now we have a dependency for building _the docs_ in the root folder's requirements file. Odd. I think we should fix that.