### PR TITLE
Implement the --django-debug plugin option with tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Unreleased
 Features
 ^^^^^^^^
 
-* Add a new option `--django-debug-mode` to specify the default DEBUG setting (#228)
+* Add a new option `--django-debug` to specify the default DEBUG setting (#228)
 
 3.4.8 (2019-02-26)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Unreleased
 Bugfixes
 ^^^^^^^^
 
-* Added a new option `--django-debug` to specify the default DEBUG setting (#228)
+* Added a new option `--django-debug-mode` to specify the default DEBUG setting (#228)
 
 3.4.8 (2019-02-26)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,12 @@
 Changelog
-=========
+
+Unreleased
+----------
+
+Bugfixes
+^^^^^^^^
+
+* Added a new option `--django-debug` to specify the default DEBUG setting (#228)
 
 3.4.8 (2019-02-26)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,10 +3,10 @@ Changelog
 Unreleased
 ----------
 
-Bugfixes
+Features
 ^^^^^^^^
 
-* Added a new option `--django-debug-mode` to specify the default DEBUG setting (#228)
+* Add a new option `--django-debug-mode` to specify the default DEBUG setting (#228)
 
 3.4.8 (2019-02-26)
 ------------------

--- a/docs/configuring_django.rst
+++ b/docs/configuring_django.rst
@@ -108,13 +108,12 @@ This plugin can then be used e.g. via ``-p`` in :pytest-confval:`addopts`.
 ``DEBUG`` setting during the test run
 -------------------------------------
 
-By default, django test runner behavior is to force DEBUG setting to False. So does the ``pytest-django``.
-But sometimes, especially for functional tests, you might want to avoid this, to debug why certain page does not work.
+Django's test runner forces ``DEBUG`` to be ``False`` by default, and so
+does ``pytest-django``.
+This can be controlled using the ``--django-debug-mode`` command line option::
 
-Command Line Option::
+    $ pytest --django-debug-mode True|False|None
 
-    $ py.test --django-debug-mode True|False|None
-
-``None`` ensure there is no override of the test settings DEBUG value
-``True`` override DEBUG to True
-``False`` override DEBUG to False
+``None`` do not override the default
+``True`` override ``DEBUG`` to be ``True``
+``False`` override ``DEBUG`` to be ``False``

--- a/docs/configuring_django.rst
+++ b/docs/configuring_django.rst
@@ -104,3 +104,17 @@ itself::
         project.app.signals.something = noop
 
 This plugin can then be used e.g. via ``-p`` in :pytest-confval:`addopts`.
+
+``DEBUG`` setting during the test run
+-------------------------------------
+
+By default, django test runner behavior is to force DEBUG setting to False. So does the ``pytest-django``.
+But sometimes, especially for functional tests, you might want to avoid this, to debug why certain page does not work.
+
+Command Line Option::
+
+    $ py.test --django-debug True|False|None
+
+``None`` ensure there is no override of the test settings DEBUG value
+``True`` override DEBUG to True
+``False`` override DEBUG to False

--- a/docs/configuring_django.rst
+++ b/docs/configuring_django.rst
@@ -110,9 +110,9 @@ This plugin can then be used e.g. via ``-p`` in :pytest-confval:`addopts`.
 
 Django's test runner forces ``DEBUG`` to be ``False`` by default, and so
 does ``pytest-django``.
-This can be controlled using the ``--django-debug-mode`` command line option::
+This can be controlled using the ``--django-debug`` command line option::
 
-    $ pytest --django-debug-mode True|False|None
+    $ pytest --django-debug True|False|None
 
 ``None`` do not override the default
 ``True`` override ``DEBUG`` to be ``True``

--- a/docs/configuring_django.rst
+++ b/docs/configuring_django.rst
@@ -113,7 +113,7 @@ But sometimes, especially for functional tests, you might want to avoid this, to
 
 Command Line Option::
 
-    $ py.test --django-debug True|False|None
+    $ py.test --django-debug-mode True|False|None
 
 ``None`` ensure there is no override of the test settings DEBUG value
 ``True`` override DEBUG to True

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -5,6 +5,7 @@ test database and provides some useful text fixtures.
 """
 
 import contextlib
+from distutils.util import strtobool
 import inspect
 from functools import reduce
 import os
@@ -105,6 +106,13 @@ def pytest_addoption(parser):
         dest="nomigrations",
         default=False,
         help="Enable Django migrations on test setup",
+    )
+    group._addoption(
+        "--django-debug",
+        action="store",
+        dest="djangodebug",
+        default="None",
+        help="Configure the DEBUG setting. Defaults to False"
     )
     parser.addini(
         CONFIGURATION_ENV, "django-configurations class to use by pytest-django."
@@ -466,7 +474,9 @@ def django_test_environment(request):
         from django.conf import settings as dj_settings
         from django.test.utils import setup_test_environment, teardown_test_environment
 
-        dj_settings.DEBUG = False
+        if request.config.getvalue('djangodebug') != 'None':
+            dj_settings.DEBUG = bool(strtobool(request.config.getvalue('djangodebug')))
+
         setup_test_environment()
         request.addfinalizer(teardown_test_environment)
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -108,9 +108,9 @@ def pytest_addoption(parser):
         help="Enable Django migrations on test setup",
     )
     group._addoption(
-        "--django-debug-mode",
+        "--django-debug",
         action="store",
-        dest="django_debug_mode",
+        dest="django_debug",
         default="None",
         help="Configure Django's DEBUG setting."
     )
@@ -475,10 +475,10 @@ def django_test_environment(request):
 
         setup_test_environment_kwargs = {}
 
-        django_debug_mode = request.config.getvalue("django_debug_mode")
-        if django_debug_mode != "None":
+        django_debug = request.config.getvalue("django_debug")
+        if django_debug != "None":
             import django
-            debug = bool(strtobool(django_debug_mode))
+            debug = bool(strtobool(django_debug))
             if django.VERSION >= (1, 11):
                 setup_test_environment_kwargs["debug"] = debug
             else:

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -108,9 +108,9 @@ def pytest_addoption(parser):
         help="Enable Django migrations on test setup",
     )
     group._addoption(
-        "--django-debug",
+        "--django-debug-mode",
         action="store",
-        dest="djangodebug",
+        dest="djangodebugmode",
         default="None",
         help="Configure the DEBUG setting. Defaults to False"
     )
@@ -474,8 +474,8 @@ def django_test_environment(request):
         from django.conf import settings as dj_settings
         from django.test.utils import setup_test_environment, teardown_test_environment
 
-        if request.config.getvalue('djangodebug') != 'None':
-            dj_settings.DEBUG = bool(strtobool(request.config.getvalue('djangodebug')))
+        if request.config.getvalue('djangodebugmode') != 'None':
+            dj_settings.DEBUG = bool(strtobool(request.config.getvalue('djangodebugmode')))
 
         setup_test_environment()
         request.addfinalizer(teardown_test_environment)

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -112,7 +112,7 @@ def pytest_addoption(parser):
         action="store",
         dest="djangodebugmode",
         default="None",
-        help="Configure the DEBUG setting. Defaults to False"
+        help="Configure the DEBUG setting. Defaults to None."
     )
     parser.addini(
         CONFIGURATION_ENV, "django-configurations class to use by pytest-django."
@@ -471,14 +471,13 @@ def django_test_environment(request):
     """
     if django_settings_is_configured():
         _setup_django()
-        from distutils.version import StrictVersion
         import django
         from django.conf import settings as dj_settings
         from django.test.utils import setup_test_environment, teardown_test_environment
 
-        if request.config.getvalue('djangodebugmode') != 'None':
-            django_debug_mode = bool(strtobool(request.config.getvalue('djangodebugmode')))
-            if StrictVersion(django.get_version()) >= StrictVersion('1.11'):
+        if request.config.getvalue("djangodebugmode") != "None":
+            django_debug_mode = bool(strtobool(request.config.getvalue("djangodebugmode")))
+            if django.VERSION >= (1, 11):
                 setup_test_environment(debug=django_debug_mode)
             else:
                 dj_settings.DEBUG = django_debug_mode

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -471,13 +471,21 @@ def django_test_environment(request):
     """
     if django_settings_is_configured():
         _setup_django()
+        from distutils.version import StrictVersion
+        import django
         from django.conf import settings as dj_settings
         from django.test.utils import setup_test_environment, teardown_test_environment
 
         if request.config.getvalue('djangodebugmode') != 'None':
-            dj_settings.DEBUG = bool(strtobool(request.config.getvalue('djangodebugmode')))
-
-        setup_test_environment()
+            django_debug_mode = bool(strtobool(request.config.getvalue('djangodebugmode')))
+            if StrictVersion(django.get_version()) >= StrictVersion('1.11'):
+                setup_test_environment(debug=django_debug_mode)
+            else:
+                dj_settings.DEBUG = django_debug_mode
+                setup_test_environment()
+        else:
+            # default setup
+            setup_test_environment()
         request.addfinalizer(teardown_test_environment)
 
 

--- a/tests/test_django_settings_module.py
+++ b/tests/test_django_settings_module.py
@@ -329,7 +329,7 @@ def test_no_debug_override(testdir, monkeypatch):
             assert settings.DEBUG is True
     """)
 
-    r = testdir.runpytest_subprocess('--django-debug=None')
+    r = testdir.runpytest_subprocess('--django-debug-mode=None')
     assert r.ret == 0
 
 
@@ -354,7 +354,7 @@ def test_override_debug_to_false(testdir, monkeypatch):
             assert settings.DEBUG is False
     """)
 
-    r = testdir.runpytest_subprocess('--django-debug=False')
+    r = testdir.runpytest_subprocess('--django-debug-mode=False')
     assert r.ret == 0
 
 
@@ -379,7 +379,7 @@ def test_override_debug_to_true(testdir, monkeypatch):
             assert settings.DEBUG is True
     """)
 
-    r = testdir.runpytest_subprocess('--django-debug=True')
+    r = testdir.runpytest_subprocess('--django-debug-mode=True')
     assert r.ret == 0
 
 

--- a/tests/test_django_settings_module.py
+++ b/tests/test_django_settings_module.py
@@ -300,7 +300,7 @@ def test_no_debug_override(testdir, monkeypatch):
             assert settings.DEBUG is True
     """)
 
-    r = testdir.runpytest_subprocess('--django-debug-mode=None')
+    r = testdir.runpytest_subprocess('--django-debug=None')
     assert r.ret == 0
 
 
@@ -325,7 +325,7 @@ def test_override_debug_to_false(testdir, monkeypatch):
             assert settings.DEBUG is False
     """)
 
-    r = testdir.runpytest_subprocess('--django-debug-mode=False')
+    r = testdir.runpytest_subprocess('--django-debug=False')
     assert r.ret == 0
 
 
@@ -350,7 +350,7 @@ def test_override_debug_to_true(testdir, monkeypatch):
             assert settings.DEBUG is True
     """)
 
-    r = testdir.runpytest_subprocess('--django-debug-mode=True')
+    r = testdir.runpytest_subprocess('--django-debug=True')
     assert r.ret == 0
 
 

--- a/tests/test_django_settings_module.py
+++ b/tests/test_django_settings_module.py
@@ -279,35 +279,6 @@ def test_django_not_loaded_without_settings(testdir, monkeypatch):
     assert result.ret == 0
 
 
-def test_debug_false(testdir, monkeypatch):
-    monkeypatch.delenv("DJANGO_SETTINGS_MODULE")
-    testdir.makeconftest(
-        """
-        from django.conf import settings
-
-        def pytest_configure():
-            settings.configure(SECRET_KEY='set from pytest_configure',
-                               DEBUG=True,
-                               DATABASES={'default': {
-                                   'ENGINE': 'django.db.backends.sqlite3',
-                                   'NAME': ':memory:'}},
-                               INSTALLED_APPS=['django.contrib.auth',
-                                               'django.contrib.contenttypes',])
-    """
-    )
-
-    testdir.makepyfile(
-        """
-        from django.conf import settings
-        def test_debug_is_false():
-            assert settings.DEBUG is False
-    """
-    )
-
-    r = testdir.runpytest_subprocess()
-    assert r.ret == 0
-
-
 def test_no_debug_override(testdir, monkeypatch):
     monkeypatch.delenv('DJANGO_SETTINGS_MODULE')
     testdir.makeconftest("""
@@ -365,7 +336,7 @@ def test_override_debug_to_true(testdir, monkeypatch):
 
         def pytest_configure():
             settings.configure(SECRET_KEY='set from pytest_configure',
-                               DEBUG=True,
+                               DEBUG=False,
                                DATABASES={'default': {
                                    'ENGINE': 'django.db.backends.sqlite3',
                                    'NAME': ':memory:'}},

--- a/tests/test_django_settings_module.py
+++ b/tests/test_django_settings_module.py
@@ -308,6 +308,81 @@ def test_debug_false(testdir, monkeypatch):
     assert r.ret == 0
 
 
+def test_no_debug_override(testdir, monkeypatch):
+    monkeypatch.delenv('DJANGO_SETTINGS_MODULE')
+    testdir.makeconftest("""
+        from django.conf import settings
+
+        def pytest_configure():
+            settings.configure(SECRET_KEY='set from pytest_configure',
+                               DEBUG=True,
+                               DATABASES={'default': {
+                                   'ENGINE': 'django.db.backends.sqlite3',
+                                   'NAME': ':memory:'}},
+                               INSTALLED_APPS=['django.contrib.auth',
+                                               'django.contrib.contenttypes',])
+    """)
+
+    testdir.makepyfile("""
+        from django.conf import settings
+        def test_debug_is_unchanged():
+            assert settings.DEBUG is True
+    """)
+
+    r = testdir.runpytest_subprocess('--django-debug=None')
+    assert r.ret == 0
+
+
+def test_override_debug_to_false(testdir, monkeypatch):
+    monkeypatch.delenv('DJANGO_SETTINGS_MODULE')
+    testdir.makeconftest("""
+        from django.conf import settings
+
+        def pytest_configure():
+            settings.configure(SECRET_KEY='set from pytest_configure',
+                               DEBUG=True,
+                               DATABASES={'default': {
+                                   'ENGINE': 'django.db.backends.sqlite3',
+                                   'NAME': ':memory:'}},
+                               INSTALLED_APPS=['django.contrib.auth',
+                                               'django.contrib.contenttypes',])
+    """)
+
+    testdir.makepyfile("""
+        from django.conf import settings
+        def test_debug_is_false():
+            assert settings.DEBUG is False
+    """)
+
+    r = testdir.runpytest_subprocess('--django-debug=False')
+    assert r.ret == 0
+
+
+def test_override_debug_to_true(testdir, monkeypatch):
+    monkeypatch.delenv('DJANGO_SETTINGS_MODULE')
+    testdir.makeconftest("""
+        from django.conf import settings
+
+        def pytest_configure():
+            settings.configure(SECRET_KEY='set from pytest_configure',
+                               DEBUG=True,
+                               DATABASES={'default': {
+                                   'ENGINE': 'django.db.backends.sqlite3',
+                                   'NAME': ':memory:'}},
+                               INSTALLED_APPS=['django.contrib.auth',
+                                               'django.contrib.contenttypes',])
+    """)
+
+    testdir.makepyfile("""
+        from django.conf import settings
+        def test_debug_is_true():
+            assert settings.DEBUG is True
+    """)
+
+    r = testdir.runpytest_subprocess('--django-debug=True')
+    assert r.ret == 0
+
+
 @pytest.mark.skipif(
     not hasattr(django, "setup"),
     reason="This Django version does not support app loading",


### PR DESCRIPTION
Follows the #228 issue, and the un-merged #231 PR.

I've taken into account @blueyed [comment](https://github.com/pytest-dev/pytest-django/pull/231#issuecomment-93381011), and included a comprehensive list of tests.

Cheers