### PR TITLE
Improve --fail-on-template-vars: use origin if available

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -527,7 +527,7 @@ def _fail_for_invalid_template_variable(request):
             else:
                 msg = "Undefined template variable '%s'" % var
             if self.fail:
-                pytest.fail(msg, pytrace=False)
+                pytest.fail(msg)
             else:
                 return msg
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -483,10 +483,24 @@ def _fail_for_invalid_template_variable(request):
             """There is a test for '%s' in TEMPLATE_STRING_IF_INVALID."""
             return key == '%s'
 
-        def _get_template(self):
+        def _get_origin(self):
+            stack = inspect.stack()
+
+            # Try to use topmost `self.origin` first (Django 1.9+, and with
+            # TEMPLATE_DEBUG)..
+            for f in stack[2:]:
+                func = f[3]
+                if func == 'render':
+                    frame = f[0]
+                    try:
+                        origin = frame.f_locals['self'].origin
+                    except (AttributeError, KeyError):
+                        continue
+                    if origin is not None:
+                        return origin
+
             from django.template import Template
 
-            stack = inspect.stack()
             # finding the ``render`` needle in the stack
             frame = reduce(
                 lambda x, y: y[3] == 'render' and 'base.py' in y[1] and y or x,
@@ -502,14 +516,14 @@ def _fail_for_invalid_template_variable(request):
             # ``django.template.base.Template``
             template = f_locals['self']
             if isinstance(template, Template):
-                return template
+                return template.name
 
         def __mod__(self, var):
             """Handle TEMPLATE_STRING_IF_INVALID % var."""
-            template = self._get_template()
-            if template:
+            origin = self._get_origin()
+            if origin:
                 msg = "Undefined template variable '%s' in '%s'" % (
-                    var, template.name)
+                    var, origin)
             else:
                 msg = "Undefined template variable '%s'" % var
             if self.fail:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -97,7 +97,7 @@ def test_invalid_template_variable(django_testdir):
         origin = "'invalid_template.html'"
     result.stdout.fnmatch_lines_random([
         "tpkg/test_the_test.py F.",
-        "Undefined template variable 'invalid_var' in {}".format(origin)
+        "E * Failed: Undefined template variable 'invalid_var' in {}".format(origin)
     ])
 
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -73,6 +73,10 @@ def test_invalid_template_variable(django_testdir):
         """, 'views.py')
     django_testdir.create_app_file(
         "<div>{{ invalid_var }}</div>",
+        'templates/invalid_template_base.html'
+    )
+    django_testdir.create_app_file(
+        "{% extends 'invalid_template_base.html' %}",
         'templates/invalid_template.html'
     )
     django_testdir.create_test_module('''
@@ -86,9 +90,14 @@ def test_invalid_template_variable(django_testdir):
             client.get('/invalid_template/')
         ''')
     result = django_testdir.runpytest_subprocess('-s', '--fail-on-template-vars')
+
+    if get_django_version() >= (1, 9):
+        origin = "'*/tpkg/app/templates/invalid_template_base.html'"
+    else:
+        origin = "'invalid_template.html'"
     result.stdout.fnmatch_lines_random([
         "tpkg/test_the_test.py F.",
-        "Undefined template variable 'invalid_var' in 'invalid_template.html'",
+        "Undefined template variable 'invalid_var' in {}".format(origin)
     ])
 
 


### PR DESCRIPTION
This will be there with Django 1.9+ always, and in case of
`settings.TEMPLATE_DEBUG` before.  It also not go up to the Template,
but uses the nearest location (which is required with extending
templates).

Using `django.template.base.Origin` also gives the benefit of having the
full/absolute path.

btw: I suggested to not throw it with the `default` filter in Django in https://github.com/django/django/pull/8200 - we might add it in pytest-django already / instead (if it gets not accepted in Django).