### PR TITLE
Do not tear down database when run with --reuse-db. Fixes #411

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -106,7 +106,7 @@ def django_db_setup(
                 verbosity=pytest.config.option.verbose,
             )
 
-    if not django_db_keepdb:
+    if not request.config.getvalue('reuse_db'):
         request.addfinalizer(teardown_database)
 
 


### PR DESCRIPTION
This will only teardown the database when --reuse-db is not used. It restores the behaviour from before the database fixture refactor and will make it possible to reuse a database with initial test data.