### PR TITLE
Make InvalidVarException._get_origin a staticmethod

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -483,7 +483,8 @@ def _fail_for_invalid_template_variable(request):
             """There is a test for '%s' in TEMPLATE_STRING_IF_INVALID."""
             return key == '%s'
 
-        def _get_origin(self):
+        @staticmethod
+        def _get_origin():
             stack = inspect.stack()
 
             # Try to use topmost `self.origin` first (Django 1.9+, and with


### PR DESCRIPTION
As per https://www.quantifiedcode.com/app/project/ffc21345b6884ba6bf92a1c95f9362fd/diff/d4f42eae622dea861fa6e628b9f52da6026c43b3/af04673a2ba97d6244489edac946cc1bc29a0533/issues?groups=code_patterns%3A7I7lGdCx%3Af0,code_patterns%3Akv4o9Hx2%3Af0.