### PR TITLE
Use django-configurations==2.0 in tests

### DIFF
--- a/tests/test_django_configurations.py
+++ b/tests/test_django_configurations.py
@@ -15,9 +15,9 @@ except ImportError as e:
                     'https://github.com/jezdez/django-configurations/issues/65')  # noqa
 
 BARE_SETTINGS = '''
-from configurations import Settings
+from configurations import Configuration
 
-class MySettings(Settings):
+class MySettings(Configuration):
     # At least one database must be configured
     DATABASES = {
         'default': {

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
 
 [testenv]
 deps =
-    django-configurations==1.0
+    django-configurations==2.0
     pytest-xdist==1.15
 
     checkqa: flake8


### PR DESCRIPTION
It was pinned to 1.0 before, and should cause test failures now.

Ref: https://github.com/pytest-dev/pytest-django/issues/483