### PR TITLE
Allow setting the live server port.

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -302,10 +302,17 @@ def live_server(request):
     addr = (request.config.getvalue('liveserver') or
             os.getenv('DJANGO_LIVE_TEST_SERVER_ADDRESS'))
 
-    if addr and django.VERSION >= (1, 11) and ':' in addr:
-        request.config.warn('D001', 'Specifying a live server port is not supported '
-                            'in Django 1.11. This will be an error in a future '
-                            'pytest-django release.')
+    if addr and ':' in addr:
+        if django.VERSION >= (1, 11):
+            ports = addr.split(':')[1]
+            if '-' in ports or ',' in ports:
+                request.config.warn('D001',
+                                    'Specifying multiple live server ports is not supported '
+                                    'in Django 1.11. This will be an error in a future '
+                                    'pytest-django release.')
+            elif django.VERSION < (1, 11, 2):
+                request.config.warn('D001', 'Specifying a live server port is not supported '
+                                    'in Django >= 1.11 < 1.11.2.')
 
     if not addr:
         if django.VERSION < (1, 11):

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -310,9 +310,6 @@ def live_server(request):
                                     'Specifying multiple live server ports is not supported '
                                     'in Django 1.11. This will be an error in a future '
                                     'pytest-django release.')
-            elif django.VERSION < (1, 11, 2):
-                request.config.warn('D001', 'Specifying a live server port is not supported '
-                                    'in Django >= 1.11 < 1.11.2.')
 
     if not addr:
         if django.VERSION < (1, 11):

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -37,8 +37,16 @@ class LiveServer(object):
             host, possible_ports = parse_addr(addr)
             self.thread = LiveServerThread(host, possible_ports,
                                            **liveserver_kwargs)
-        else:
+        elif django.VERSION < (1, 11, 2):
             host = addr
+            self.thread = LiveServerThread(host, **liveserver_kwargs)
+        else:
+            try:
+                host, port = addr.split(':')
+            except ValueError:
+                host = addr
+            else:
+                liveserver_kwargs['port'] = int(port)
             self.thread = LiveServerThread(host, **liveserver_kwargs)
 
         self._live_server_modified_settings = modify_settings(

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -37,9 +37,6 @@ class LiveServer(object):
             host, possible_ports = parse_addr(addr)
             self.thread = LiveServerThread(host, possible_ports,
                                            **liveserver_kwargs)
-        elif django.VERSION < (1, 11, 2):
-            host = addr
-            self.thread = LiveServerThread(host, **liveserver_kwargs)
         else:
             try:
                 host, port = addr.split(':')

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -319,19 +319,6 @@ class TestLiveServer:
         with pytest.raises(HTTPError):
             urlopen(live_server + '/static/a_file.txt').read()
 
-    @pytest.mark.skipif(get_django_version() < (1, 11) or get_django_version() >= (1, 11, 2),
-                        reason='Django >= 1.11 < 1.11.2 required')
-    def test_specified_port_error_message_django_111(self, django_testdir):
-        django_testdir.create_test_module("""
-        def test_with_live_server(live_server):
-            pass
-        """)
-
-        result = django_testdir.runpytest_subprocess('--liveserver=localhost:1234')
-        result.stdout.fnmatch_lines([
-            '*Specifying a live server port is not supported in Django >= 1.11 < 1.11.2.'
-        ])
-
     @pytest.mark.skipif(get_django_version() < (1, 11),
                         reason='Django >= 1.11 required')
     def test_specified_port_range_error_message_django_111(self, django_testdir):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -319,8 +319,8 @@ class TestLiveServer:
         with pytest.raises(HTTPError):
             urlopen(live_server + '/static/a_file.txt').read()
 
-    @pytest.mark.skipif(get_django_version() < (1, 11),
-                        reason='Django >= 1.11 required')
+    @pytest.mark.skipif(get_django_version() < (1, 11) or get_django_version() >= (1, 11, 2),
+                        reason='Django >= 1.11 < 1.11.2 required')
     def test_specified_port_error_message_django_111(self, django_testdir):
         django_testdir.create_test_module("""
         def test_with_live_server(live_server):
@@ -329,7 +329,20 @@ class TestLiveServer:
 
         result = django_testdir.runpytest_subprocess('--liveserver=localhost:1234')
         result.stdout.fnmatch_lines([
-            '*Specifying a live server port is not supported in Django 1.11. This '
+            '*Specifying a live server port is not supported in Django >= 1.11 < 1.11.2.'
+        ])
+
+    @pytest.mark.skipif(get_django_version() < (1, 11),
+                        reason='Django >= 1.11 required')
+    def test_specified_port_range_error_message_django_111(self, django_testdir):
+        django_testdir.create_test_module("""
+        def test_with_live_server(live_server):
+            pass
+        """)
+
+        result = django_testdir.runpytest_subprocess('--liveserver=localhost:1234-2345')
+        result.stdout.fnmatch_lines([
+            '*Specifying multiple live server ports is not supported in Django 1.11. This '
             'will be an error in a future pytest-django release.*'
         ])
 


### PR DESCRIPTION
As the possibility to define a fixed live server port has been added back in Django 1.11.2 (https://code.djangoproject.com/ticket/28212), I'd like to have it available in pytest-django as well.