### PR TITLE
Patch DNS_NAME used in mail module by default

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,13 +4,24 @@ Changelog
 3.3.0 (unreleased)
 ------------------
 
-* Fix test for classmethod with Django TestCases (#597, #598).
-* Fix RemovedInPytest4Warning: MarkInfo objects are deprecated (#596, #603)
+Features
+^^^^^^^^
+
+* Added new fixtures ``django_mail_dnsname`` and ``django_mail_patch_dns``,
+  used by ``mailoutbox`` to monkeypatch the ``DNS_NAME`` used in
+  :py:mod:`django.core.mail` to improve performance and
+  reproducibility.
+
+Bug fixes
+^^^^^^^^^
+
+* Fixed test for classmethod with Django TestCases (#597, #598).
+* Fixed RemovedInPytest4Warning: MarkInfo objects are deprecated (#596, #603)
 
 3.2.1
 -----
 
-Fix automatic deployment to PyPI.
+* Fixed automatic deployment to PyPI.
 
 3.2.0
 -----

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "_ext"))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
     'pytestdocs',
 ]
 
@@ -60,3 +61,9 @@ html_static_path = ['_static']
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'pytest-djangodoc'
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'django': ('http://docs.djangoproject.com/en/dev/',
+               'http://docs.djangoproject.com/en/dev/_objects/'),
+}

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -264,7 +264,7 @@ Example
 
 
 ``mailoutbox``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 A clean email outbox to which Django-generated emails are sent.
 
@@ -283,6 +283,12 @@ Example
         assert m.body == 'body'
         assert m.from_email == 'from@example.com'
         assert list(m.to) == ['to@example.com']
+
+
+This uses the ``django_mail_patch_dns`` fixture, which patches
+``DNS_NAME`` used by :py:mod:`django.core.mail` with the value from
+the ``django_mail_dnsname`` fixture, which defaults to
+"fake-tests.example.com".
 
 
 Automatic cleanup

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -440,12 +440,23 @@ def _dj_autoclear_mailbox():
 
 
 @pytest.fixture(scope='function')
-def mailoutbox(monkeypatch, _dj_autoclear_mailbox):
+def mailoutbox(monkeypatch, django_mail_patch_dns, _dj_autoclear_mailbox):
     if not django_settings_is_configured():
         return
 
     from django.core import mail
     return mail.outbox
+
+
+@pytest.fixture(scope='function')
+def django_mail_patch_dns(monkeypatch, django_mail_dnsname):
+    from django.core import mail
+    monkeypatch.setattr(mail.message, 'DNS_NAME', django_mail_dnsname)
+
+
+@pytest.fixture(scope='function')
+def django_mail_dnsname(monkeypatch):
+    return 'fake-tests.example.com'
 
 
 @pytest.fixture(autouse=True, scope='function')


### PR DESCRIPTION
DNS lookups can be really slow, and it is good to skip them in general,
and have a more stable header in the mails.

TODO:
- [x] doc