### PR TITLE
django_client_class fixture to use custom client class

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -121,6 +121,29 @@ Example
         response = my_view(request)
         assert response.status_code == 200
 
+``django_client_class`` - ``django.test.Client.__class__``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Type of a `django.test.Client`_. In case you use a custom client class this can be overridden.
+
+.. _django.test.Client: https://docs.djangoproject.com/en/dev/topics/testing/tools/#the-test-client
+
+Example
+"""""""
+
+::
+
+    import pytest
+    from django.test.client import Client
+
+    class CustomClient(Client):
+        pass
+
+    @pytest.fixture()
+    def django_client_class():
+        return CustomClient
+
+
 ``client`` - ``django.test.Client``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -15,7 +15,7 @@ from .django_compat import is_django_unittest
 from .lazy_django import skip_if_no_django
 
 __all__ = ['django_db_setup', 'db', 'transactional_db', 'admin_user',
-           'django_user_model', 'django_username_field',
+           'django_user_model', 'django_username_field', 'django_client_class',
            'client', 'admin_client', 'rf', 'settings', 'live_server',
            '_live_server_helper', 'django_assert_num_queries']
 
@@ -175,13 +175,19 @@ def transactional_db(request, django_db_setup, django_db_blocker):
 
 
 @pytest.fixture()
-def client():
-    """A Django test client instance."""
+def django_client_class():
+    """Django test client class."""
     skip_if_no_django()
 
     from django.test.client import Client
 
-    return Client()
+    return Client
+
+
+@pytest.fixture()
+def client(django_client_class):
+    """A Django test client instance."""
+    return django_client_class()
 
 
 @pytest.fixture()
@@ -219,11 +225,9 @@ def admin_user(db, django_user_model, django_username_field):
 
 
 @pytest.fixture()
-def admin_client(db, admin_user):
+def admin_client(db, django_client_class, admin_user):
     """A Django test client logged in as an admin user."""
-    from django.test.client import Client
-
-    client = Client()
+    client = django_client_class()
     client.login(username=admin_user.username, password='password')
     return client
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -174,7 +174,7 @@ def transactional_db(request, django_db_setup, django_db_blocker):
     _django_db_fixture_helper(True, request, django_db_blocker)
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def django_client_class():
     """Django test client class."""
     skip_if_no_django()

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -16,6 +16,7 @@ import pytest
 
 from .django_compat import is_django_unittest  # noqa
 from .fixtures import django_assert_num_queries  # noqa
+from .fixtures import django_client_class  # noqa
 from .fixtures import django_db_setup  # noqa
 from .fixtures import django_db_use_migrations  # noqa
 from .fixtures import django_db_keepdb  # noqa

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -26,6 +26,25 @@ def test_client(client):
     assert isinstance(client, Client)
 
 
+def test_custom_client_class(django_testdir):
+    django_testdir.makepyfile("""
+        import pytest
+        from django.test.client import Client
+
+        class CustomClient(Client):
+            pass
+
+        @pytest.fixture()
+        def django_client_class():
+            return CustomClient
+
+        def test_client(client):
+            assert type(client) is CustomClient
+    """)
+    r = django_testdir.runpytest_subprocess()
+    assert r.ret == 0
+
+
 @pytest.mark.django_db
 def test_admin_client(admin_client):
     assert isinstance(admin_client, Client)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -34,15 +34,15 @@ def test_custom_client_class(django_testdir):
         class CustomClient(Client):
             pass
 
-        @pytest.fixture()
+        @pytest.fixture
         def django_client_class():
             return CustomClient
 
         def test_client(client):
             assert type(client) is CustomClient
     """)
-    r = django_testdir.runpytest_subprocess()
-    assert r.ret == 0
+    result = django_testdir.runpytest_subprocess('--tb=short')
+    assert result.ret == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Rest Framework [0] and other Django extensions use their own custom django client.
Instead of overwriting all client fixtures it is desirable to be able to overwrite client class only.

This is analogue to Django SimpleTestCase [1] where client_class can be overridden as well.

[0] http://www.django-rest-framework.org/api-guide/testing/#apiclient
[1] https://docs.djangoproject.com/en/1.11/_modules/django/test/testcases/#SimpleTestCase