### PR TITLE
.coveragerc: use a single source, but includes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
 parallel = true
-source = pytest_django,pytest_django_test,tests
+source = .
+include = pytest_django/*,pytest_django_test/*,tests/*
 branch = true


### PR DESCRIPTION
This makes it easier for Codecov to parse it.