### PR TITLE
Travis: skip coverage reporting with pypy/pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Use container-based environment (faster startup, allows caches).
 sudo: false
 language: python
+dist: trusty
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - python: 3.6
       env: TOXENV=py36-dj20-postgres
     - python: 3.6
-      env: TOXENV=py36-dj111-postgres
+      env: TOXENV=py36-dj111-sqlite
     - python: 3.6
       env: TOXENV=py36-checkqa
 
@@ -19,7 +19,7 @@ matrix:
       env: TOXENV=py35-dj110-postgres
 
     - python: 3.4
-      env: TOXENV=py34-dj19-postgres
+      env: TOXENV=py34-dj19-sqlite_file
 
     - python: 2.7
       env: TOXENV=py27-dj111-mysql_innodb
@@ -30,9 +30,9 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-checkqa
 
+    # pypy/pypy3: not included with coverage reports (much slower then).
     - python: pypy
       env: TOXENV=pypy-dj111-sqlite_file
-
     - python: pypy3
       env: TOXENV=pypy3-dj110-sqlite
 
@@ -57,9 +57,13 @@ install:
 
   - pip install tox==2.9.1
   - |
-    if [[ "${TOXENV%-checkqa}" == "$TOXENV" ]]; then
+    # Setup coverage tracking, but not with "checkqa" nor "pypy*".
+    if [[ "${TOXENV%-checkqa}" == "$TOXENV" ]] && [[ "${TOXENV#pypy}" == "$TOXENV" ]]; then
+      PYTEST_DJANGO_COVERAGE=1
       export PYTEST_ADDOPTS='--cov=pytest_django --cov=tests --cov=pytest_django_test --cov-report=term-missing:skip-covered'
       export _PYTESTDJANGO_TOX_EXTRA_DEPS=pytest-cov
+    else
+      PYTEST_DJANGO_COVERAGE=0
     fi
 
 script:
@@ -68,7 +72,7 @@ script:
 after_success:
   - |
     set -ex
-    if [[ "${TOXENV%-checkqa}" == "$TOXENV" ]]; then
+    if [[ "$PYTEST_DJANGO_COVERAGE" = 1 ]]; then
       pip install codecov
 
       coverage combine


### PR DESCRIPTION
The current builds are very slow (~30mins for pypy3).
Try newer/current versions.

Slowness comes from running with coverage, so I will likely only skip this, but use the versions provided by Travis by default.