### PR TITLE
doc: fix typo

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -346,10 +346,9 @@ transactions. This example uses Django's fixture loading mechanism, but it can
 be replaced with any way of loading data into the database.
 
 Notice that :fixture:`django_db_setup` is in the argument list. This may look
-odd at first, but it will make sure that the sure that the original
-pytest-django fixture is used to create the test database. When
-``call_command`` is invoked, the test database is already prepared and
-configured.
+odd at first, but it will make sure that the original pytest-django fixture
+is used to create the test database. When ``call_command`` is invoked, the
+test database is already prepared and configured.
 
 Put this in ``conftest.py``::
 


### PR DESCRIPTION
Fix typo in the section: Populate the database with initial test data.