### PR TITLE
Add fixture for asserting maximum number of database queries

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -249,8 +249,13 @@ Example
 ``django_assert_num_queries``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. fixture:: django_assert_num_queries
+
 This fixture allows to check for an expected number of DB queries.
-It currently only supports the default database.
+
+It wraps `django.test.utils.CaptureQueriesContext`.  A non-default DB
+connection can be passed in using the `connection` keyword argument, and it
+will yield the wrapped CaptureQueriesContext instance.
 
 
 Example
@@ -270,8 +275,11 @@ Example
 ``django_assert_max_num_queries``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. fixture:: django_assert_max_num_queries
+
 This fixture allows to check for an expected maximum number of DB queries.
-It currently only supports the default database.
+
+It is a specialized version of :fixture:`django_assert_num_queries`.
 
 
 Example

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -265,6 +265,24 @@ Example
             Item.objects.create('baz')
 
 
+``django_assert_max_num_queries``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This fixture allows to check for an expected maximum number of DB queries.
+It currently only supports the default database.
+
+
+Example
+"""""""
+
+::
+
+    def test_max_queries(django_assert_max_num_queries):
+        with django_assert_max_num_queries(3):
+            Item.objects.create('foo')
+            Item.objects.create('bar')
+
+
 ``mailoutbox``
 ~~~~~~~~~~~~~~
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -259,10 +259,12 @@ Example
 ::
 
     def test_queries(django_assert_num_queries):
-        with django_assert_num_queries(3):
+        with django_assert_num_queries(3) as captured:
             Item.objects.create('foo')
             Item.objects.create('bar')
             Item.objects.create('baz')
+
+        assert 'foo' in captured.captured_queries[0]['sql']
 
 
 ``django_assert_max_num_queries``

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -355,9 +355,12 @@ def _live_server_helper(request):
 
 
 @contextmanager
-def _assert_num_queries(config, num, exact=True):
-    from django.db import connection
+def _assert_num_queries(config, num, exact=True, connection=None):
     from django.test.utils import CaptureQueriesContext
+
+    if connection is None:
+        from django.db import connection
+
     verbose = config.getoption('verbose') > 0
     with CaptureQueriesContext(connection) as context:
         yield context

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -360,14 +360,16 @@ def _assert_num_queries(config, num, exact=True):
     from django.test.utils import CaptureQueriesContext
     verbose = config.getoption('verbose') > 0
     with CaptureQueriesContext(connection) as context:
-        yield
+        yield context
         num_queries = len(context)
         failed = num != num_queries if exact else num < num_queries
         if failed:
             msg = "Expected to perform {} queries {}{}".format(
                 num,
                 '' if exact else 'or less ',
-                'but {} were done'.format(num_queries)
+                'but {} done'.format(
+                    num_queries == 1 and '1 was' or '%d were' % (num_queries,)
+                )
             )
             if verbose:
                 sqls = (q['sql'] for q in context.captured_queries)

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -16,6 +16,7 @@ import pytest
 
 from .django_compat import is_django_unittest  # noqa
 from .fixtures import django_assert_num_queries  # noqa
+from .fixtures import django_assert_max_num_queries  # noqa
 from .fixtures import django_db_setup  # noqa
 from .fixtures import django_db_use_migrations  # noqa
 from .fixtures import django_db_keepdb  # noqa

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -138,6 +138,21 @@ def test_django_assert_num_queries_output_verbose(django_testdir):
     assert result.ret == 1
 
 
+@pytest.mark.django_db
+def test_django_assert_num_queries_db_connection(django_assert_num_queries):
+    from django.db import connection
+
+    with django_assert_num_queries(1, connection=connection):
+        Item.objects.create(name='foo')
+
+    with django_assert_num_queries(1, connection=None):
+        Item.objects.create(name='foo')
+
+    with pytest.raises(AttributeError):
+        with django_assert_num_queries(1, connection=False):
+            pass
+
+
 class TestSettings:
     """Tests for the settings fixture, order matters"""
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -64,8 +64,22 @@ def test_django_assert_num_queries_db(django_assert_num_queries):
             Item.objects.create(name='quux')
 
 
+@pytest.mark.django_db
+def test_django_assert_max_num_queries_db(django_assert_max_num_queries):
+    with django_assert_max_num_queries(2):
+        Item.objects.create(name='1-foo')
+        Item.objects.create(name='2-bar')
+
+    with pytest.raises(pytest.fail.Exception):
+        with django_assert_max_num_queries(2):
+            Item.objects.create(name='1-foo')
+            Item.objects.create(name='2-bar')
+            Item.objects.create(name='3-quux')
+
+
 @pytest.mark.django_db(transaction=True)
-def test_django_assert_num_queries_transactional_db(transactional_db, django_assert_num_queries):
+def test_django_assert_num_queries_transactional_db(
+        transactional_db, django_assert_num_queries):
     with transaction.atomic():
 
         with django_assert_num_queries(3):


### PR DESCRIPTION
Often I don't want to test against the exact number of queries performed by a particular piece of code but just be sure that changes to the codebase don't end up in an unnoticed excessive increase of queries.

[django-test-plus](https://github.com/revsys/django-test-plus#assertnumquerieslessthannumber---context) has a really nice helper for this kind of scenario: https://github.com/revsys/django-test-plus#assertnumquerieslessthannumber---context

This PR tries to port the same functionality to `pytest-django`.

Open issues:
* No tests so far
* Does renaming `assert_num_queries` to `assert_exact_num_queries` make sense?

Cheers,
Andreas