### PR TITLE
tox: require pytest<3.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 
 [testenv]
 deps =
-    pytest>=3.0,<4.0
+    pytest>=3.0,<3.3
     django-configurations==2.0
     pytest-xdist==1.15
     {env:_PYTESTDJANGO_TOX_EXTRA_DEPS:}


### PR DESCRIPTION
Workaround for https://github.com/pytest-dev/pytest-django/issues/550.