### PR TITLE
Add changelog for 3.2 version

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-3.1.3
+3.2
 -----
 
 Features

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 Features
 ^^^^^^^^
-* A new fixture `django_assert_num_queries` was introduced, to allow to test against the number of database queries.
+* Added new fixture `django_assert_num_queries` for testing the number of database queries.
 * `--fail-on-template-vars` has been improved and should now return full/absolute path.
 
 Bug fixes

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,12 +6,12 @@ Changelog
 
 Features
 ^^^^^^^^
-* A new fixture `django_assert_num_queries` was introduced, to allow to test against the number of datase queries.
+* A new fixture `django_assert_num_queries` was introduced, to allow to test against the number of database queries.
 * `--fail-on-template-vars` has been improved and should now return full/absolute path.
 
 Bug fixes
 ^^^^^^^^^
-* Numerous fixed in the documentation. These should not go unnoticed 🌟
+* Numerous fixes in the documentation. These should not go unnoticed 🌟
 
 Compatibility
 ^^^^^^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+3.1.3
+-----
+
+Features
+^^^^^^^^
+* A new fixture `django_assert_num_queries` was introduced, to allow to test against the number of datase queries.
+* `--fail-on-template-vars` has been improved and should now return full/absolute path.
+
+Bug fixes
+^^^^^^^^^
+* Numerous fixed in the documentation. These should not go unnoticed 🌟
+
+Compatibility
+^^^^^^^^^^^^^
+* Django 2.0 support has been added 🎉
+* Django < 1.8 support has been dropped.
+
 3.1.2
 -----
 


### PR DESCRIPTION
As discussed in #473 it seems the only lacking point to release 3.1.3 version is the changelog. I have went through [all commits since last version](https://github.com/pytest-dev/pytest-django/compare/3.1.2...master) and written it down.

Let me know if I can improve it in any way, I'm happy to do so.

Additionally, thank you for working on `pytest-django`, it helps a ton with writing clean tests 🙏 