### PR TITLE
Fix --reuse-db and --create-db not working together. Fixes #411

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -229,6 +229,15 @@ command line options.
 
 This fixture is by default requested from :fixture:`django_db_setup`.
 
+django_db_createdb
+""""""""""""""""
+
+.. fixture:: django_db_createdb
+
+Returns whether or not the database is to be re-created before running any tests.
+
+This fixture is by default requested from :fixture:`django_db_setup`.
+
 django_db_blocker
 """""""""""""""""
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -61,8 +61,12 @@ def django_db_use_migrations(request):
 
 @pytest.fixture(scope='session')
 def django_db_keepdb(request):
-    return (request.config.getvalue('reuse_db') and not
-            request.config.getvalue('create_db'))
+    return request.config.getvalue('reuse_db')
+
+
+@pytest.fixture(scope='session')
+def django_db_createdb(request):
+    return request.config.getvalue('create_db')
 
 
 @pytest.fixture(scope='session')
@@ -72,6 +76,7 @@ def django_db_setup(
     django_db_blocker,
     django_db_use_migrations,
     django_db_keepdb,
+    django_db_createdb,
     django_db_modify_db_settings,
 ):
     """Top level fixture to ensure test databases are available"""
@@ -82,7 +87,7 @@ def django_db_setup(
     if not django_db_use_migrations:
         _disable_native_migrations()
 
-    if django_db_keepdb:
+    if django_db_keepdb and not django_db_createdb:
         setup_databases_args['keepdb'] = True
 
     with django_db_blocker.unblock():

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -19,6 +19,7 @@ from .fixtures import django_assert_num_queries  # noqa
 from .fixtures import django_db_setup  # noqa
 from .fixtures import django_db_use_migrations  # noqa
 from .fixtures import django_db_keepdb  # noqa
+from .fixtures import django_db_createdb  # noqa
 from .fixtures import django_db_modify_db_settings  # noqa
 from .fixtures import django_db_modify_db_settings_xdist_suffix  # noqa
 from .fixtures import _live_server_helper  # noqa

--- a/tests/test_db_setup.py
+++ b/tests/test_db_setup.py
@@ -75,6 +75,7 @@ def test_db_reuse(django_testdir):
     ])
 
     # Make sure the database has been re-created and the mark is gone
+    assert db_exists()
     assert not mark_exists()
 
 


### PR DESCRIPTION
Improves upon https://github.com/pytest-dev/pytest-django/pull/476 which fixes https://github.com/pytest-dev/pytest-django/issues/411

Also fixes the test to include db exist check.
