### PR TITLE
Automatically release to PyPI with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 dist: trusty
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - python: 3.6
@@ -33,6 +33,20 @@ matrix:
 
     - python: 3.6
       env: TOXENV=checkqa
+
+    - stage: PyPI Release
+      if: tag IS present
+      script: skip
+      install: skip
+      after_success: skip
+      deploy:
+        provider: pypi
+        user: blueyed
+        password:
+          secure: "FY7qbX/N0XRcH8hVk00SsQWvNIkuxKvY7Br4ghRnHvleHG3YulJ7WbJnik+9eoBGeMfJeNyzBfVjpeo1ZIq9IZBiyTdNfG/sZFsC5LOoG/CPxPH3nD9JktI2HoBMnlSbGg/MMHjY+wXuOY647U/3qNedcnQmGztYt6QWi5DRxu8="
+        on:
+          tags: true
+        distributions: "sdist bdist_wheel"
 
   allow_failures:
     - env: TOXENV=py36-djmaster-postgres

--- a/tox.ini
+++ b/tox.ini
@@ -65,23 +65,3 @@ deps =
     readme_renderer
 commands =
     python setup.py check -r -s
-
-# Release tooling
-[testenv:build]
-basepython = python3.6
-skip_install = true
-deps =
-    wheel
-    setuptools
-commands =
-    python setup.py -q sdist bdist_wheel
-
-[testenv:release]
-basepython = python3.5
-skip_install = true
-deps =
-    {[testenv:build]deps}
-    twine >= 1.9.1
-commands =
-    {[testenv:build]commands}
-    twine upload -s --skip-existing dist/*


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest-django/issues/473#issuecomment-353352328

This adds a Travis build stage to automatically release to PyPI when a new tag is pushed.

To finish this up, the encrypted PyPI password will need to be added to `.travis.yml` attn @blueyed 

```
gem install travis
travis encrypt
# Enter PyPI password then hit Ctrl+D
```

Copy the output into `.travis.yml`

```yaml
      provider: pypi
      user: blueyed
      password:
        secure: '... encrypted password from `travis encrypt` ...'
```