### PR TITLE
Use cascade when truncating

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -120,7 +120,11 @@ def _django_db_fixture_helper(transactional, request, django_db_blocker):
     request.addfinalizer(django_db_blocker.restore)
 
     if transactional:
-        from django.test import TransactionTestCase as django_case
+        from django.conf import settings
+        from django.test import TransactionTestCase
+
+        class django_case(TransactionTestCase):
+            available_apps = settings.INSTALLED_APPS
     else:
         from django.test import TestCase as django_case
 


### PR DESCRIPTION
This fixes truncation of tables with foreign keys, for example when single table inheriting a model not in INSTALLED_APPS.

I've gone ahead and fixed the issue with this small change. Though it sort of depends on the internals of Django TransactionTestCase but I figured it's OK since the attribute in question is part of the [public API](https://github.com/django/django/blob/1.11.9/django/test/testcases.py#L820-L821) and it's sort of [documented](https://github.com/django/django/blob/1.11.9/django/test/testcases.py#L839-L841).

---

Regarding testing, this happens when you inherit from a model not in INSTALLED_APPS. But I'm not familiar with the tests and thus not sure how to set that up.

In package/module foo.models:
```
from django.db import models

class Foo(models.Model):
    name = models.Charfield()
```

In package/model bar.models:
```
from django.db import models
from foo.models import Foo

class Bar(Foo):
    title = models.Charfield()
```

See #254 for the original PR.