### PR TITLE
Support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ dist: trusty
 jobs:
   fast_finish: true
   include:
+    # py37 is not available in trusty dist, and requires sudo=true with xenial.
     - python: 3.7
       env: TOXENV=py37-dj21-postgres
       dist: xenial
+      sudo: true
 
     - python: 3.6
       env: TOXENV=py36-djmaster-postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ dist: trusty
 jobs:
   fast_finish: true
   include:
-    - python: 3.6
-      env: TOXENV=py36-djmaster-postgres
+    - python: 3.7
+      env: TOXENV=py37-djmaster-postgres
+
     - python: 3.6
       env: TOXENV=py36-dj20-postgres
     - python: 3.6
@@ -51,7 +52,7 @@ jobs:
         distributions: "sdist bdist_wheel"
 
   allow_failures:
-    - env: TOXENV=py36-djmaster-postgres
+    - env: TOXENV=py37-djmaster-postgres
 
 install:
   # Create pip wrapper script, using travis_retry (a function) and

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   include:
     # py37 is not available in trusty dist, and requires sudo=true with xenial.
     - python: 3.7
-      env: TOXENV=py37-dj21-postgres
+      env: TOXENV=py37-dj21-sqlite
       dist: xenial
       sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ jobs:
   fast_finish: true
   include:
     - python: 3.7
-      env: TOXENV=py37-djmaster-postgres
+      env: TOXENV=py37-dj21-postgres
+      dist: xenial
 
     - python: 3.6
-      env: TOXENV=py36-dj20-postgres
+      env: TOXENV=py36-djmaster-postgres
     - python: 3.6
-      env: TOXENV=py36-dj21-postgres
+      env: TOXENV=py36-dj20-postgres
     - python: 3.6
       env: TOXENV=py36-dj111-sqlite
 
@@ -52,7 +53,7 @@ jobs:
         distributions: "sdist bdist_wheel"
 
   allow_failures:
-    - env: TOXENV=py37-djmaster-postgres
+    - env: TOXENV=py36-djmaster-postgres
 
 install:
   # Create pip wrapper script, using travis_retry (a function) and

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ pytest-django allows you to test your Django project/applications with the
 
   * Django: 1.8-1.11, 2.0-2.1,
     and latest master branch (compatible at the time of each release)
-  * Python: CPython 2.7, 3.4-3.6 or PyPy 2, 3
+  * Python: CPython 2.7, 3.4-3.7 or PyPy 2, 3
   * pytest: >=3.6
 
 * Licence: BSD

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
                  'Programming Language :: Python :: 3.4',
                  'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
+                 'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: Implementation :: CPython',
                  'Programming Language :: Python :: Implementation :: PyPy',
                  'Topic :: Software Development :: Testing',


### PR DESCRIPTION
Travis does not support 3.7 on the Trusty images: https://docs.travis-ci.com/user/languages/python/#development-releases-support.. :/