### PR TITLE
.coveragerc: move include to report section

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 parallel = true
 source = .
-include = pytest_django/*,pytest_django_test/*,tests/*
 branch = true
+[report]
+include = pytest_django/*,pytest_django_test/*,tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ after_success:
     if [[ "$PYTEST_DJANGO_COVERAGE" = 1 ]]; then
       pip install codecov
 
+      coverage --version
       coverage combine
       coverage xml
 


### PR DESCRIPTION
Fixes the following warning:

> Coverage.py warning: --include is ignored because --source is set
> (include-ignored)

Ref: https://bitbucket.org/ned/coveragepy/issues/621/include-ignored-warning-when-using