### PR TITLE
Add pytest as a dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ wheel
 twine
 flake8
 Flask-Sphinx-Themes
+pytest


### PR DESCRIPTION
Add pytest as a dependency, in requirements.txt, so that projects using pytest-django do not need to insert pytest before pytest-django in their own requirements.

Without pytest as a dependency for pytest-django, then if a user of pytest-django doesn't have pytest in their own requirements, listed prior to pytest-django, pip and pipenv will not know that pytest is required before pytest-django.  Even if pytest is subsequently installed, if pytest-django is installed before pytest, then an attempt to run tests will fail, with this error:

E   django.core.exceptions.ImproperlyConfigured: Requested setting DEFAULT_INDEX_TABLESPACE, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.

If one attempts to specify the path to the Django settings by using the pytest option --ds, which is supplied by pytest-django, pytest says it has no such option.

This is speculation on my part, because I haven't looked at the pytest-django setup, but it implies pytest-django was unable to add its environment variables and options into pytest, since pytest was not present at the time pytest-django was installed.

Adding the dependency would be helpful to projects using pytest-django so they don't need to know they need to add pytest before pytest-django, or at all, in their own requirements.  This came up for the django-graph-api project recently, when I adapted its installation instructions for Windows, and so was repeatedly testing installation from scratch.  Other folks working on the project had not done a from-scratch installation recently, and so already had pytest installed.  As a temporary workaround, I've added pytest before pytest-django in our own Pipfile (which we use instead of requirements.txt)

Apologies, but I'm including the following explanation to avoid a potential argument that each project should "know" what it depends on, even indirectly, and include all such indirect dependencies in the proper order:  pip, pipenv, and other installers expect that each module specifies its own dependencies, so that they can construct a dependency graph, and install modules in the required order, and so that downstream projects don't need to know all the dependencies needed by the modules they use, nor what order they must be installed in.

Let me know if you'd like an issue added for this, for discussion, or if the pull request is sufficient to have a place to chat.