### PR TITLE
Look in child dirs when discovering django project

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Features
+^^^^^^^^
+* pytest-django now searches the immediate subdirectories of the current
+  working directory when trying to find the Django project.
+
 3.1.2
 -----
 

--- a/docs/managing_python_path.rst
+++ b/docs/managing_python_path.rst
@@ -18,10 +18,10 @@ By default, pytest-django tries to find Django projects by automatically
 looking for the project's ``manage.py`` file and adding its directory to the
 Python path.
 
-Looking for the ``manage.py`` file uses the same algorithm as pytest uses to
-find ``pytest.ini``, ``tox.ini`` and ``setup.cfg``: Each test root directories
-parents will be searched for ``manage.py`` files, and it will stop when the
-first file is found.
+Looking for the ``manage.py`` file uses the following algorithm:
+Beginning at each directory given on the command line (or the current working
+directory if none is given), the directory itself, its immediate children and
+its parents are searched, and it will stop when the first file is found.
 
 If you have a custom project setup, have none or multiple ``manage.py`` files
 in your project, the automatic detection may not be correct. See

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -127,6 +127,9 @@ def _add_django_project_to_path(args):
         for arg in args:
             if is_django_project(arg):
                 return arg
+            for child in arg.iterdir():
+                if is_django_project(child):
+                    return child
             for parent in arg.parents:
                 if is_django_project(parent):
                     return parent

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,11 @@ setup(
     long_description=read('README.rst'),
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     setup_requires=['setuptools_scm>=1.11.1'],
-    install_requires=['pytest>=2.9'],
+    install_requires=[
+        'pytest>=2.9',
+        'pathlib;python_version<"3.4"',
+        'six',
+    ],
     classifiers=['Development Status :: 5 - Production/Stable',
                  'Framework :: Django',
                  'Framework :: Django :: 1.8',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,16 @@ import copy
 import shutil
 from textwrap import dedent
 
-import py
+import pathlib
 import pytest
+import six
 from django.conf import settings
 
 from pytest_django_test.db_helpers import DB_NAME, TEST_DB_NAME
 
 pytest_plugins = 'pytester'
 
-REPOSITORY_ROOT = py.path.local(__file__).join('..')
+REPOSITORY_ROOT = pathlib.Path(__file__).parent
 
 
 def pytest_configure(config):
@@ -99,12 +100,12 @@ def django_testdir(request, testdir, monkeypatch):
 
     tpkg_path.ensure('__init__.py')
 
-    app_source = REPOSITORY_ROOT.dirpath('pytest_django_test/app')
+    app_source = REPOSITORY_ROOT / '../pytest_django_test/app'
     test_app_path = tpkg_path.join('app')
 
     # Copy the test app to make it available in the new test run
-    shutil.copytree(py.builtin._totext(app_source),
-                    py.builtin._totext(test_app_path))
+    shutil.copytree(six.text_type(app_source),
+                    six.text_type(test_app_path))
     tpkg_path.join("the_settings.py").write(test_settings)
 
     monkeypatch.setenv('DJANGO_SETTINGS_MODULE', 'tpkg.the_settings')


### PR DESCRIPTION
Hi! :wave: 
In a lot of projects I work on, the django project is in a `src` subfolder of the repository. :fol
These changes allow pytest-django to discover the project when `pytest` is run from the root folder of the repository.

While reading the code, I discovered that `py` is in maintenance mode, so I replaced it with `pathlib`, which is in the standard library.

What do you think about these changes?

PS:
I tried to run `tox` locally, but there were some errors regarding the postgres database. Running one using Docker didn't work either. I also had a little trouble understanding how the django-project-directory-discovery is tested in general, if you feel like this feature deserves a test, please give me some pointers on how to do it.