### PR TITLE
Add new fixture `q` of type QueryDict

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -285,6 +285,23 @@ Example
         assert list(m.to) == ['to@example.com']
 
 
+``q``
+~~~~~
+
+A mutable instance of ``django.http.QueryDict``.
+
+Example
+"""""""
+
+::
+
+    def test_api_view(client, q):
+        q['first_name'] = 'james'
+        response = client.get(
+            '{}?{}'.format(reverse('user-list'), q.urlencode())
+        )
+        assert 'james' in response.data['result']
+
 Automatic cleanup
 -----------------
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -18,7 +18,7 @@ from .lazy_django import skip_if_no_django
 __all__ = ['django_db_setup', 'db', 'transactional_db', 'admin_user',
            'django_user_model', 'django_username_field',
            'client', 'admin_client', 'rf', 'settings', 'live_server',
-           '_live_server_helper', 'django_assert_num_queries']
+           '_live_server_helper', 'django_assert_num_queries', 'q']
 
 
 @pytest.fixture(scope='session')
@@ -364,3 +364,28 @@ def django_assert_num_queries(pytestconfig):
                 pytest.fail(msg)
 
     return _assert_num_queries
+
+
+@pytest.fixture(scope='function')
+def q():
+    """
+    Django's QueryDict has a very helpful function, urlencode(), which
+    greatly helps in constructing urls with query parameters.
+
+    However, by default it is not mutable. This fixture creates a mutable
+    instance of QueryDict.
+
+    You can add items to it like so:
+    >>> q.update(other_dict)
+    or
+    >>> q['param'] = "value"
+
+    To render the items in a url string:
+    >>> '{}?{}'.format(reverse('some-route', kwargs={'pk': obj.id}), q.urlencode())
+
+
+    Please check the original documentation under:
+    https://docs.djangoproject.com/en/2.0/ref/request-response/#querydict-objects
+    """
+    from django.http import QueryDict
+    return QueryDict(mutable=True)

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -33,6 +33,7 @@ from .fixtures import live_server  # noqa
 from .fixtures import rf  # noqa
 from .fixtures import settings  # noqa
 from .fixtures import transactional_db  # noqa
+from .fixtures import q  # noqa
 from .pytest_compat import getfixturevalue
 
 from .lazy_django import django_settings_is_configured, skip_if_no_django

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -28,7 +28,10 @@ def test_client(client):
 
 def test_q(q):
     from django.http import QueryDict
+
     assert isinstance(q, QueryDict)
+    q['some_key'] = 'some value'
+    q.update({'other_key': 'other_value'})
 
 
 @pytest.mark.django_db

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -26,6 +26,11 @@ def test_client(client):
     assert isinstance(client, Client)
 
 
+def test_q(q):
+    from django.http import QueryDict
+    assert isinstance(q, QueryDict)
+
+
 @pytest.mark.django_db
 def test_admin_client(admin_client):
     assert isinstance(admin_client, Client)


### PR DESCRIPTION
I frequently use this fixture in almost all django/drf projects when I test against APIs. Instead of implementing it again and again, I thought it could be added to pytest-django.

`q` is a [mutable QueryDict](https://docs.djangoproject.com/en/2.0/ref/request-response/#querydict-objects). Its major benefit is [urlencode()](https://docs.djangoproject.com/en/2.0/ref/request-response/#django.http.QueryDict.urlencode) which I use for constructing query parameters in URLs.

This PR includes documentation in docs/helpers.rst :)