### PR TITLE
#596 MarkInfo deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ _build
 /.coverage
 /htmlcov/
 .cache
+.pytest_cache/
 .Python
 .eggs
 *.egg

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -378,10 +378,10 @@ def _django_db_marker(request):
     This will dynamically request the ``db`` or ``transactional_db``
     fixtures as required by the django_db marker.
     """
-    marker = request.keywords.get('django_db', None)
+    marker = request.node.get_closest_marker('django_db')
     if marker:
-        validate_django_db(marker)
-        if marker.transaction:
+        transaction = validate_django_db(marker)
+        if transaction:
             getfixturevalue(request, 'transactional_db')
         else:
             getfixturevalue(request, 'db')
@@ -447,7 +447,7 @@ def mailoutbox(monkeypatch, _dj_autoclear_mailbox):
 @pytest.fixture(autouse=True, scope='function')
 def _django_set_urlconf(request):
     """Apply the @pytest.mark.urls marker, internal to pytest-django."""
-    marker = request.keywords.get('urls', None)
+    marker = request.node.get_closest_marker('urls')
     if marker:
         skip_if_no_django()
         import django.conf
@@ -457,9 +457,9 @@ def _django_set_urlconf(request):
             # Removed in Django 2.0
             from django.core.urlresolvers import clear_url_caches, set_urlconf
 
-        validate_urls(marker)
+        urls = validate_urls(marker)
         original_urlconf = django.conf.settings.ROOT_URLCONF
-        django.conf.settings.ROOT_URLCONF = marker.urls
+        django.conf.settings.ROOT_URLCONF = urls
         clear_url_caches()
         set_urlconf(None)
 
@@ -656,8 +656,8 @@ def validate_django_db(marker):
     the marker which will have the correct value.
     """
     def apifun(transaction=False):
-        marker.transaction = transaction
-    apifun(*marker.args, **marker.kwargs)
+        return transaction
+    return apifun(*marker.args, **marker.kwargs)
 
 
 def validate_urls(marker):
@@ -667,5 +667,5 @@ def validate_urls(marker):
     marker which will have the correct value.
     """
     def apifun(urls):
-        marker.urls = urls
-    apifun(*marker.args, **marker.kwargs)
+        return urls
+    return apifun(*marker.args, **marker.kwargs)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     long_description=read('README.rst'),
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     setup_requires=['setuptools_scm>=1.11.1'],
-    install_requires=['pytest>=2.9'],
+    install_requires=['pytest>=3.6'],
     classifiers=['Development Status :: 5 - Production/Stable',
                  'Framework :: Django',
                  'Framework :: Django :: 1.8',

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 
 [testenv]
 deps =
-    pytest>=3.0,<3.6
+    pytest>=3.6
     django-configurations==2.0
     pytest-xdist==1.15
     {env:_PYTESTDJANGO_TOX_EXTRA_DEPS:}


### PR DESCRIPTION
Here is a quick go at removing the deprecation warning so tests won't break if running with `-W error`.