### PR TITLE
live_server: use self.thread.terminate() directly

### DIFF
--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -60,9 +60,7 @@ class LiveServer(object):
 
     def stop(self):
         """Stop the server"""
-        # .terminate() was added in Django 1.7
-        terminate = getattr(self.thread, 'terminate', lambda: None)
-        terminate()
+        self.thread.terminate()
         self.thread.join()
         self._live_server_modified_settings.disable()
 


### PR DESCRIPTION
This can be done now since support for Django 1.7 has been dropped.