### PR TITLE
live_server: override settings only per test

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -340,9 +340,17 @@ def _live_server_helper(request):
     The separate helper is required since live_server can not request
     transactional_db directly since it is session scoped instead of
     function-scoped.
+
+    It will also override settings only for the duration of the test.
     """
-    if 'live_server' in request.funcargnames:
-        getfixturevalue(request, 'transactional_db')
+    if 'live_server' not in request.funcargnames:
+        return
+
+    getfixturevalue(request, 'transactional_db')
+
+    live_server = getfixturevalue(request, 'live_server')
+    live_server._live_server_modified_settings.enable()
+    request.addfinalizer(live_server._live_server_modified_settings.disable)
 
 
 @pytest.fixture(scope='function')

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -49,7 +49,6 @@ class LiveServer(object):
         self._live_server_modified_settings = modify_settings(
             ALLOWED_HOSTS={'append': host},
         )
-        self._live_server_modified_settings.enable()
 
         self.thread.daemon = True
         self.thread.start()
@@ -62,7 +61,6 @@ class LiveServer(object):
         """Stop the server"""
         self.thread.terminate()
         self.thread.join()
-        self._live_server_modified_settings.disable()
 
     @property
     def url(self):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -223,8 +223,33 @@ class TestSettings:
 
 
 class TestLiveServer:
+    def test_settings_before(self):
+        from django.conf import settings
+
+        assert '%s.%s' % (
+            settings.__class__.__module__,
+            settings.__class__.__name__) == 'django.conf.Settings'
+        TestLiveServer._test_settings_before_run = True
+
     def test_url(self, live_server):
         assert live_server.url == force_text(live_server)
+
+    def test_change_settings(self, live_server, settings):
+        assert live_server.url == force_text(live_server)
+
+    def test_settings_restored(self):
+        """Ensure that settings are restored after test_settings_before."""
+        import django
+        from django.conf import settings
+
+        assert TestLiveServer._test_settings_before_run is True
+        assert '%s.%s' % (
+            settings.__class__.__module__,
+            settings.__class__.__name__) == 'django.conf.Settings'
+        if django.VERSION >= (1, 11):
+            assert settings.ALLOWED_HOSTS == ['testserver']
+        else:
+            assert settings.ALLOWED_HOSTS == ['*']
 
     def test_transactions(self, live_server):
         if not connections_support_transactions():


### PR DESCRIPTION
This fixes settings to be restored after a test using the
``live_server`` fixture.  Previously all tests afterwards were using the
overridden settings.