### PR TITLE
Update documented pytest requirements changed in d9a9e9a8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ pytest-django allows you to test your Django project/applications with the
 
   * Django: 1.8-1.11, 2.0 and latest master branch (compatible at the time of each release)
   * Python: CPython 2.7, 3.4-3.6 or PyPy 2, 3
-  * pytest: >2.9.x
+  * pytest: >=3.6
 
 * Licence: BSD
 * Project maintainers: Andreas Pelme, Floris Bruynooghe and Daniel Hahler

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,11 @@ Bug fixes
 * Fixed scope of overridden settings with live_server fixture: previously they
   were visible to following tests (#612).
 
+Compatibility
+^^^^^^^^^^^^^
+
+ * `pytest` requirements changed from >=2.9 to >=3.6
+
 3.2.1
 -----
 


### PR DESCRIPTION
This is in response to [this comment](https://github.com/pytest-dev/pytest-django/pull/603#issuecomment-397795443) on #603.

I updated the changelog in case someone goes scanning through it later on, but it is too late for anyone who has the current version. I wouldn't have thought anyone would pin to 3.3.0, and then want to use their local `README.rst` or `docs/changelog.rst`, so I don't think there'd be any practical benifit in making something like a [`3.3.0.post1`](https://www.python.org/dev/peps/pep-0440/#post-releases)