### PR TITLE
Use pathlib2

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -11,7 +11,6 @@ import os
 import sys
 import types
 
-import pathlib2 as pathlib
 import pytest
 
 from .django_compat import is_django_unittest  # noqa
@@ -37,6 +36,11 @@ from .fixtures import settings  # noqa
 from .fixtures import transactional_db  # noqa
 
 from .lazy_django import django_settings_is_configured, skip_if_no_django
+
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
 
 
 SETTINGS_MODULE_ENV = 'DJANGO_SETTINGS_MODULE'

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -11,7 +11,7 @@ import os
 import sys
 import types
 
-import pathlib
+import pathlib2 as pathlib
 import pytest
 
 from .django_compat import is_django_unittest  # noqa

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     setup_requires=['setuptools_scm>=1.11.1'],
     install_requires=[
         'pytest>=3.6',
-        'pathlib;python_version<"3.4"',
+        'pathlib2;python_version<"3.4"',
     ],
     extras_require={
         'docs': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,16 @@ import copy
 import shutil
 from textwrap import dedent
 
-import pathlib2 as pathlib
 import pytest
 import six
 from django.conf import settings
 
 from pytest_django_test.db_helpers import DB_NAME, TEST_DB_NAME
+
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
 
 pytest_plugins = 'pytester'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import copy
 import shutil
 from textwrap import dedent
 
-import pathlib
+import pathlib2 as pathlib
 import pytest
 import six
 from django.conf import settings


### PR DESCRIPTION
The dependency on `pathlib` was added in #631. A backport is needed for Python <3.4.

The `pathlib` package [on PyPI](https://pypi.org/project/pathlib/) is maintenance-only and comes with a message about using `pathlib2` for an up-to-date version. Also `pytest` itself uses `pathlib2` so currently I'm getting both packages installed when one would do.

This change in `setup.py` seems to be all that's needed to switch.