### PR TITLE
Fix sys.path.insert for project path: insert absolute path

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -139,7 +139,7 @@ def _add_django_project_to_path(args):
 
     project_dir = find_django_path(args)
     if project_dir:
-        sys.path.insert(0, str(project_dir))
+        sys.path.insert(0, str(project_dir.absolute()))
         return PROJECT_FOUND % project_dir
     return PROJECT_NOT_FOUND
 

--- a/tests/test_manage_py_scan.py
+++ b/tests/test_manage_py_scan.py
@@ -17,7 +17,12 @@ def test_django_project_found(django_testdir, monkeypatch):
         assert sys.path[0] == cwd
 
         # The one inserted by us.  It should be absolute.
-        assert sys.path[1] == cwd
+        # py37 has it in sys.path[1] already, but otherwise there is an empty
+        # entry first.
+        if sys.path[1] == '':
+            assert sys.path[2] == cwd
+        else:
+            assert sys.path[1] == cwd
     """)
     monkeypatch.chdir('django_project_root')
     result = django_testdir.runpytest_subprocess('.')

--- a/tests/test_manage_py_scan.py
+++ b/tests/test_manage_py_scan.py
@@ -25,6 +25,27 @@ def test_django_project_found(django_testdir):
 
 @pytest.mark.django_project(project_root='django_project_root',
                             create_manage_py=True)
+def test_django_project_found_absolute(django_testdir, monkeypatch):
+    django_testdir.create_test_module("""
+    def test_foobar():
+        import os, sys
+
+        # The one inserted by Python, see comment for test above.
+        assert sys.path[0] == os.getcwd()
+
+        # The one inserted by us.  It should be absolute.
+        assert sys.path[1] == os.getcwd()
+    """)
+    monkeypatch.chdir('django_project_root')
+    result = django_testdir.runpytest_subprocess('-s', '.')
+    assert result.ret == 0
+
+    outcomes = result.parseoutcomes()
+    assert outcomes['passed'] == 1
+
+
+@pytest.mark.django_project(project_root='django_project_root',
+                            create_manage_py=True)
 def test_django_project_found_invalid_settings(django_testdir, monkeypatch):
     monkeypatch.setenv('DJANGO_SETTINGS_MODULE', 'DOES_NOT_EXIST')
 


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-django/issues/637