### PR TITLE
Travis: pin pytest-cov==2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ install:
     if [[ "$SKIP_COVERAGE" != "1" ]]; then
       PYTEST_DJANGO_COVERAGE=1
       export PYTEST_ADDOPTS='--cov=pytest_django --cov=tests --cov=pytest_django_test --cov-report=term-missing:skip-covered'
-      export _PYTESTDJANGO_TOX_EXTRA_DEPS=pytest-cov
+      export _PYTESTDJANGO_TOX_EXTRA_DEPS='pytest-cov==2.5.1'
     else
       PYTEST_DJANGO_COVERAGE=0
     fi


### PR DESCRIPTION
Debugging dropped coverage: https://codecov.io/gh/pytest-dev/pytest-django/tree/efc08dc83d79be801725a494821b2f0c0bb50fad

(reported OK in the build, but not on codecov)