### PR TITLE
Back to pytest-cov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 parallel = 1
-source = ${PYTESTDJANGO_COVERAGE_SRC}.
+source = pytest_django,pytest_django_test,tests/
 branch = 1
 
 [report]

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ after_success:
   - |
     set -ex
     if [[ "${TOXENV%-coverage}" != "$TOXENV" ]]; then
+      .tox/$TOXENV/bin/coverage xml
       codecov_flags=${TOXENV%-coverage}
       codecov_flags=${codecov_flags//-/,}
       bash <(curl -s https://codecov.io/bash) -Z -X gcov -X xcode -X gcovout -F "$codecov_flags"

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     mysql_innodb: mysql-python==1.2.5
 
     postgres: psycopg2-binary
-    coverage: coverage-enable-subprocess
+    coverage: pytest-cov
 
 setenv =
     PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
@@ -32,19 +32,15 @@ setenv =
     sqlite:       DJANGO_SETTINGS_MODULE=pytest_django_test.settings_sqlite
     sqlite_file:  DJANGO_SETTINGS_MODULE=pytest_django_test.settings_sqlite_file
 
-    coverage: PYTESTDJANGO_TEST_RUNNER=coverage run -m pytest
-    coverage: COVERAGE_PROCESS_START={toxinidir}/.coveragerc
-    coverage: COVERAGE_FILE={toxinidir}/.coverage
-    coverage: PYTESTDJANGO_COVERAGE_SRC={toxinidir}/
+    coverage: PYTESTDJANGO_TEST_ARGS=--cov --cov-report=term
+    coverage: COV_CORE_SOURCE=pytest_django,pytest_django_test,{toxinidir}/tests
+    coverage: COV_CORE_CONFIG={toxinidir}/.coveragerc
+    coverage: COV_CORE_DATAFILE={toxinidir}/.coverage.eager
 
 passenv = PYTEST_ADDOPTS
 usedevelop = True
 commands =
-    coverage: coverage erase
-    {env:PYTESTDJANGO_TEST_RUNNER:pytest} {posargs:tests}
-    coverage: coverage combine
-    coverage: coverage report
-    coverage: coverage xml
+    pytest {env:PYTESTDJANGO_TEST_ARGS:} {posargs:tests}
 
 [testenv:checkqa]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,10 @@ usedevelop = True
 commands =
     pytest {env:PYTESTDJANGO_TEST_ARGS:} {posargs:tests}
 
+    # pytest-cov handles combining, but due to the eager setup there is an
+    # outer (empty) one, which we append (mainly for cleanup).
+    coverage: coverage combine -a
+
 [testenv:checkqa]
 deps =
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ setenv =
     sqlite_file:  DJANGO_SETTINGS_MODULE=pytest_django_test.settings_sqlite_file
 
     coverage: PYTESTDJANGO_TEST_ARGS=--cov --cov-report=term
-    coverage: COV_CORE_SOURCE=pytest_django,pytest_django_test,{toxinidir}/tests
+    coverage: COV_CORE_SOURCE={toxinidir}
     coverage: COV_CORE_CONFIG={toxinidir}/.coveragerc
     coverage: COV_CORE_DATAFILE={toxinidir}/.coverage.eager
 


### PR DESCRIPTION
The problem was the eager setup, which produced an outer
`.coverage.eager.*` file, next to the `.coverage` one that pytest-cov as
of 2.6.0 generates/combines already, and then `coverage combine` would
delete that - it requires `coverage combine -a` to keep the existing
`.coverage` data.