### PR TITLE
Refine the django.conf module check to see if the settings really are configured

### DIFF
--- a/pytest_django/lazy_django.py
+++ b/pytest_django/lazy_django.py
@@ -15,16 +15,18 @@ def skip_if_no_django():
 
 
 def django_settings_is_configured():
-    # Avoid importing Django if it has not yet been imported
-    if (
-        not os.environ.get("DJANGO_SETTINGS_MODULE")
-        and "django.conf" not in sys.modules
-    ):
-        return False
+    """Return whether the Django settings module has been configured.
 
-    # If DJANGO_SETTINGS_MODULE is defined at this point, Django is assumed to
-    # always be loaded.
-    return True
+    This uses either the DJANGO_SETTINGS_MODULE environment variable, or the
+    configured flag in the Django settings object if django.conf has already
+    been imported.
+    """
+    ret = bool(os.environ.get("DJANGO_SETTINGS_MODULE"))
+
+    if not ret and "django.conf" in sys.modules:
+        return sys.modules["django.conf"].settings.configured
+
+    return ret
 
 
 def get_django_version():


### PR DESCRIPTION
Some modules, e.g. hypothesis, load some Django modules for their own fixtures.
This means that the `django.conf` module sometimes gets loaded, even though it's
never used (and the settings are not initialized).

This causes unrelated test failures when pytest_django is installed, as
pytest_django considers that having a loaded django.conf means the settings are
set up and ready to be modified. The Django settings object provides a flag to
check this condition, which we now use.

Add a regression test that mimics what hypothesis did which makes pytest-django
fail.

Closes #599.