### PR TITLE
Don't add email to extra arguments

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -252,15 +252,17 @@ def admin_user(db, django_user_model, django_username_field):
     """
     UserModel = django_user_model
     username_field = django_username_field
+    username = "admin@example.com" if username_field == "email" else "admin"
 
     try:
-        user = UserModel._default_manager.get(**{username_field: "admin"})
+
+        user = UserModel._default_manager.get(**{username_field: username})
     except UserModel.DoesNotExist:
         extra_fields = {}
         if username_field not in ("username", "email"):
             extra_fields[username_field] = "admin"
         user = UserModel._default_manager.create_superuser(
-            "admin", "admin@example.com", "password", **extra_fields
+            username, "admin@example.com", "password", **extra_fields
         )
     return user
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -255,7 +255,6 @@ def admin_user(db, django_user_model, django_username_field):
     username = "admin@example.com" if username_field == "email" else "admin"
 
     try:
-
         user = UserModel._default_manager.get(**{username_field: username})
     except UserModel.DoesNotExist:
         extra_fields = {}

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -257,7 +257,7 @@ def admin_user(db, django_user_model, django_username_field):
         user = UserModel._default_manager.get(**{username_field: "admin"})
     except UserModel.DoesNotExist:
         extra_fields = {}
-        if username_field != "username":
+        if username_field not in ("username", "email"):
             extra_fields[username_field] = "admin"
         user = UserModel._default_manager.create_superuser(
             "admin", "admin@example.com", "password", **extra_fields

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -469,6 +469,7 @@ class TestLiveServer:
         django_testdir.runpytest_subprocess("--liveserver=localhost:%s" % port)
 
 
+@pytest.mark.parametrize('username_field', ('email', 'identifier'))
 @pytest.mark.django_project(
     extra_settings="""
     AUTH_USER_MODEL = 'app.MyCustomUser'
@@ -482,7 +483,7 @@ class TestLiveServer:
     ROOT_URLCONF = 'tpkg.app.urls'
     """
 )
-def test_custom_user_model(django_testdir):
+def test_custom_user_model(django_testdir, username_field):
     django_testdir.create_app_file(
         """
         from django.contrib.auth.models import AbstractUser
@@ -491,8 +492,8 @@ def test_custom_user_model(django_testdir):
         class MyCustomUser(AbstractUser):
             identifier = models.CharField(unique=True, max_length=100)
 
-            USERNAME_FIELD = 'identifier'
-        """,
+            USERNAME_FIELD = '%s'
+        """ % (username_field),
         "models.py",
     )
     django_testdir.create_app_file(


### PR DESCRIPTION
Email could be a username field. If this is the case, we shouldn't add it into kwargs, because that would cause the same argument to be passed twice. I didn't create test case for that because this would require setting up custom user model and injecting it into a test case. Maybe there is an easier way I didn't see?