### PR TITLE
Use request.config instead of pytest.config

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -103,14 +103,14 @@ def django_db_setup(
 
     with django_db_blocker.unblock():
         db_cfg = setup_databases(
-            verbosity=pytest.config.option.verbose,
+            verbosity=request.config.option.verbose,
             interactive=False,
             **setup_databases_args
         )
 
     def teardown_database():
         with django_db_blocker.unblock():
-            teardown_databases(db_cfg, verbosity=pytest.config.option.verbose)
+            teardown_databases(db_cfg, verbosity=request.config.option.verbose)
 
     if not django_db_keepdb:
         request.addfinalizer(teardown_database)


### PR DESCRIPTION
Will be deprecated in pytest 4.1.
Ref: https://github.com/pytest-dev/pytest/commit/b88c3f8f828