### PR TITLE
Fix DB renaming fixture for Multi-DB environment

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -47,9 +47,9 @@ def django_db_modify_db_settings_xdist_suffix(request):
 
         if not test_name:
             if db_settings["ENGINE"] == "django.db.backends.sqlite3":
-                return ":memory:"
-            else:
-                test_name = "test_{}".format(db_settings["NAME"])
+                continue
+
+            test_name = "test_{}".format(db_settings["NAME"])
 
         # Put a suffix like _gw0, _gw1 etc on xdist processes
         xdist_suffix = getattr(request.config, "slaveinput", {}).get("slaveid")


### PR DESCRIPTION
For Django configurations using multiple databases, there's a subtle bug
that doesn't rename databases, if there's an SQLite one that triggers
the `return` statement in the existing feature.

As the return value doesn't seem to be used, we can just move to the
next iteration in the `for`-loop, and evaluate the following DB.

A test was added to consider this scenario.