### PR TITLE
Rename test databases when running parallel Tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _build
 .env
 /.coverage.*
 /.coverage
+/coverage.xml
 /htmlcov/
 .cache
 .pytest_cache/

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -191,10 +191,32 @@ If you need to customize the location of your test database, this is the
 fixture you want to override.
 
 The default implementation of this fixture requests the
-:fixture:`django_db_modify_db_settings_xdist_suffix` to provide compatibility
+:fixture:`django_db_modify_db_settings_parallel_suffix` to provide compatibility
 with pytest-xdist.
 
 This fixture is by default requested from :fixture:`django_db_setup`.
+
+django_db_modify_db_settings_parallel_suffix
+""""""""""""""""""""""""""""""""""""""""""""
+
+.. fixture:: django_db_modify_db_settings_parallel_suffix
+
+Requesting this fixture will add a suffix to the database name when the tests
+are run via `pytest-xdist`, or via `tox` in parallel mode.
+
+This fixture is by default requested from
+:fixture:`django_db_modify_db_settings`.
+
+django_db_modify_db_settings_tox_suffix
+"""""""""""""""""""""""""""""""""""""""
+
+.. fixture:: django_db_modify_db_settings_tox_suffix
+
+Requesting this fixture will add a suffix to the database name when the tests
+are run via `tox` in parallel mode.
+
+This fixture is by default requested from
+:fixture:`django_db_modify_db_settings_parallel_suffix`.
 
 django_db_modify_db_settings_xdist_suffix
 """""""""""""""""""""""""""""""""""""""""
@@ -202,10 +224,10 @@ django_db_modify_db_settings_xdist_suffix
 .. fixture:: django_db_modify_db_settings_xdist_suffix
 
 Requesting this fixture will add a suffix to the database name when the tests
-are run via pytest-xdist.
+are run via `pytest-xdist`.
 
 This fixture is by default requested from
-:fixture:`django_db_modify_db_settings`.
+:fixture:`django_db_modify_db_settings_parallel_suffix`.
 
 django_db_use_migrations
 """"""""""""""""""""""""

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -22,6 +22,8 @@ from .fixtures import django_db_use_migrations  # noqa
 from .fixtures import django_db_keepdb  # noqa
 from .fixtures import django_db_createdb  # noqa
 from .fixtures import django_db_modify_db_settings  # noqa
+from .fixtures import django_db_modify_db_settings_parallel_suffix  # noqa
+from .fixtures import django_db_modify_db_settings_tox_suffix  # noqa
 from .fixtures import django_db_modify_db_settings_xdist_suffix  # noqa
 from .fixtures import _live_server_helper  # noqa
 from .fixtures import admin_client  # noqa


### PR DESCRIPTION
When tests are executed using Tox in parallel, modify the test database
names, to avoid name collisions between processes.

This change renames the existing
`django_db_modify_db_settings_xdist_suffix` fixture, to a generic
`django_db_modify_db_settings_parallel_suffix` one, in case more
scenarios/tools have to be considered in the future.

It also handles projects where both `pytest-xdist` and parallel `tox`
are being using, generating database names like
`test_default_py37-django21_gw0`.

This change is based on `tox` new parallel mode [0].

Resolves #678.

[0] https://github.com/tox-dev/tox/pull/1102