### PR TITLE
Remove deprecated Sphinx directive add_description_unit()

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ intersphinx_mapping = {
 
 def setup(app):
     # Allow linking to pytest's confvals.
-    app.add_description_unit(
+    app.add_object_type(
         "confval",
         "pytest-confval",
         objname="configuration value",


### PR DESCRIPTION
Sphinx 2.0 dropped support for it.

See pytest-dev/pytest#4922