### PR TITLE
django_db_setup: warn instead of crash with teardown errors

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -110,7 +110,14 @@ def django_db_setup(
 
     def teardown_database():
         with django_db_blocker.unblock():
-            teardown_databases(db_cfg, verbosity=request.config.option.verbose)
+            try:
+                teardown_databases(db_cfg, verbosity=request.config.option.verbose)
+            except Exception as exc:
+                request.node.warn(
+                    pytest.PytestWarning(
+                        "Error when trying to teardown test databases: %r" % exc
+                    )
+                )
 
     if not django_db_keepdb:
         request.addfinalizer(teardown_database)


### PR DESCRIPTION
Previously it would cause pytest to crash, and this is just something to
warn about anyway.

Ref: https://github.com/django/channels/issues/1091#issuecomment-489389450