### PR TITLE
Mock out migrate.Command with `--no-migrations`

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -155,9 +155,16 @@ def _django_db_fixture_helper(
 
 def _disable_native_migrations():
     from django.conf import settings
+    from django.core.management.commands.migrate import Command
+
     from .migrations import DisableMigrations
 
     settings.MIGRATION_MODULES = DisableMigrations()
+
+    def migrate_noop(self, *args, **kwargs):
+        pass
+
+    Command.handle = migrate_noop
 
 
 # ############### User visible fixtures ################

--- a/tests/test_db_setup.py
+++ b/tests/test_db_setup.py
@@ -340,9 +340,10 @@ class TestNativeMigrations(object):
         )
 
         result = django_testdir.runpytest_subprocess(
-            "--nomigrations", "--tb=short", "-v"
+            "--nomigrations", "--tb=short", "-vv",
         )
         assert result.ret == 0
+        assert "Operations to perform:" not in result.stdout.str()
         result.stdout.fnmatch_lines(["*test_inner_migrations*PASSED*"])
 
     def test_migrations_run(self, django_testdir):


### PR DESCRIPTION
It would still add some overhead (especially with regard to output
noise).