### PR TITLE
Email based user model without username field

### DIFF
--- a/pytest_django/django_compat.py
+++ b/pytest_django/django_compat.py
@@ -12,3 +12,13 @@ def is_django_unittest(request_or_item):
         return False
 
     return issubclass(cls, SimpleTestCase)
+
+def get_all_user_model_fields(UserModel):
+    """
+    Returns all usermodel fields and takes removal of Model._meta.get_all_field_names() into account
+    https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api
+    """
+    try:
+        return UserModel._meta.get_all_field_names()
+    except AttributeError:
+        return [x.name for x in UserModel._meta.get_fields()]

--- a/pytest_django/django_compat.py
+++ b/pytest_django/django_compat.py
@@ -12,14 +12,3 @@ def is_django_unittest(request_or_item):
         return False
 
     return issubclass(cls, SimpleTestCase)
-
-
-def get_all_user_model_fields(UserModel):
-    """
-    Returns all user model fields and respects removal of Model._meta.get_all_field_names()
-    https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api
-    """
-    try:
-        return UserModel._meta.get_all_field_names()
-    except AttributeError:
-        return [x.name for x in UserModel._meta.get_fields()]

--- a/pytest_django/django_compat.py
+++ b/pytest_django/django_compat.py
@@ -13,9 +13,10 @@ def is_django_unittest(request_or_item):
 
     return issubclass(cls, SimpleTestCase)
 
+
 def get_all_user_model_fields(UserModel):
     """
-    Returns all usermodel fields and takes removal of Model._meta.get_all_field_names() into account
+    Returns all user model fields and respects removal of Model._meta.get_all_field_names()
     https://docs.djangoproject.com/en/1.9/ref/models/meta/#migrating-from-the-old-api
     """
     try:

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -269,24 +269,24 @@ def admin_user(db, django_user_model, django_username_field):
     UserModel = django_user_model
     username_field = django_username_field
     username = "admin@example.com" if username_field == "email" else "admin"
+    attributes = {username_field: username}
 
     try:
-        user = UserModel._default_manager.get(**{username_field: username})
+        user = UserModel._default_manager.get(**attributes)
     except UserModel.DoesNotExist:
         all_user_model_fields = get_all_user_model_fields(UserModel)
-        extra_fields = { django_username_field: 'admin' }
 
         if 'username' in all_user_model_fields:
             # django.contrib.auth.UserManager expects a username field to be
             # present, even if a different USERNAME_FIELD is set.
-            extra_fields['username'] = 'admin'
+            attributes['username'] = 'admin'
         if 'email' in all_user_model_fields:
             # Handle both email field required for default UserManager and
             # cases where USERNAME_FIELD is the email.
-            extra_fields['email'] = 'admin@example.com'
+            attributes['email'] = 'admin@example.com'
 
         user = UserModel._default_manager.create_superuser(
-            password='password', **extra_fields
+            password='password', **attributes
         )
     return user
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -10,7 +10,7 @@ from functools import partial
 import pytest
 
 from . import live_server_helper
-from .django_compat import is_django_unittest
+from .django_compat import is_django_unittest, get_all_user_model_fields
 from .lazy_django import skip_if_no_django
 
 __all__ = [
@@ -273,20 +273,21 @@ def admin_user(db, django_user_model, django_username_field):
     try:
         user = UserModel._default_manager.get(**{username_field: username})
     except UserModel.DoesNotExist:
-        usermodel_fields = UserModel._meta.get_all_field_names()
+        all_user_model_fields = get_all_user_model_fields(UserModel)
+        extra_fields = { django_username_field: 'admin' }
 
-        extra_fields = {django_username_field: 'admin'}
-        if 'username' in usermodel_fields:
+        if 'username' in all_user_model_fields:
             # django.contrib.auth.UserManager expects a username field to be
             # present, even if a different USERNAME_FIELD is set.
             extra_fields['username'] = 'admin'
-        if 'email' in usermodel_fields:
+        if 'email' in all_user_model_fields:
             # Handle both email field required for default UserManager and
             # cases where USERNAME_FIELD is the email.
             extra_fields['email'] = 'admin@example.com'
 
         user = UserModel._default_manager.create_superuser(
-            password='password', **extra_fields)
+            password='password', **extra_fields
+        )
     return user
 
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -10,7 +10,7 @@ from functools import partial
 import pytest
 
 from . import live_server_helper
-from .django_compat import is_django_unittest, get_all_user_model_fields
+from .django_compat import is_django_unittest
 from .lazy_django import skip_if_no_django
 
 __all__ = [
@@ -274,7 +274,7 @@ def admin_user(db, django_user_model, django_username_field):
     try:
         user = UserModel._default_manager.get(**attributes)
     except UserModel.DoesNotExist:
-        all_user_model_fields = get_all_user_model_fields(UserModel)
+        all_user_model_fields = [x.name for x in UserModel._meta.get_fields()]
 
         if 'username' in all_user_model_fields:
             # django.contrib.auth.UserManager expects a username field to be

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -273,22 +273,30 @@ def admin_user(db, django_user_model, django_username_field):
     try:
         user = UserModel._default_manager.get(**{username_field: username})
     except UserModel.DoesNotExist:
-        extra_fields = {}
-        if username_field not in ("username", "email"):
-            extra_fields[username_field] = "admin"
+        usermodel_fields = UserModel._meta.get_all_field_names()
+
+        extra_fields = {django_username_field: 'admin'}
+        if 'username' in usermodel_fields:
+            # django.contrib.auth.UserManager expects a username field to be
+            # present, even if a different USERNAME_FIELD is set.
+            extra_fields['username'] = 'admin'
+        if 'email' in usermodel_fields:
+            # Handle both email field required for default UserManager and
+            # cases where USERNAME_FIELD is the email.
+            extra_fields['email'] = 'admin@example.com'
+
         user = UserModel._default_manager.create_superuser(
-            username, "admin@example.com", "password", **extra_fields
-        )
+            password='password', **extra_fields)
     return user
 
 
 @pytest.fixture()
-def admin_client(db, admin_user):
+def admin_client(db, admin_user, django_username_field):
     """A Django test client logged in as an admin user."""
     from django.test.client import Client
 
     client = Client()
-    client.login(username=admin_user.username, password="password")
+    client.login(username=getattr(admin_user, django_username_field), password='password')
     return client
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -548,8 +548,12 @@ def test_custom_user_model(django_testdir, username_field, original_username_fie
 
                 USERNAME_FIELD = '%s'
                 REQUIRED_FIELDS = []
-                username = None
                 objects = MyCustomUserManager()
+
+            username_field = MyCustomUser._meta.get_field('username')
+            local_fields = MyCustomUser._meta.local_fields
+            local_fields.remove(username_field)
+            MyCustomUser._meta.fields = local_fields
             """
             % (username_field),
             "models.py",


### PR DESCRIPTION
I recently worked on a Django project with a custom user model, which uses an email as the username field and does not use the original username field. To make pytest-django work I have locally overwritten some fixtures of pytest-django.

To eventually get rid of the overrides I added tests (extended the `test_custom_user_model` test in `tests/test_fixtures.py`) to the changes made in #246.

I hope the tests are sufficient to get this merged, if not I am open for hints to write some more.
Also I hope it's fine that I created a new pull request for this (didn't know how to proceed).
I'm pretty new to python still, so don't hesitate to nitpick on the changes made :cold_sweat: 
