### PR TITLE
Django unittests: restore "debug" function

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -522,8 +522,9 @@ def _django_setup_unittest(request, django_db_blocker):
 
     cls = request.node.cls
 
-    # implement missing (as of 1.10) debug() method for django's TestCase
-    # see pytest-dev/pytest-django#406
+    # Implement missing (as of 2.2) debug() wrapper/method for Django's TestCase.
+    # See pytest-dev/pytest-django#406.
+    # Pending PR for Django: https://github.com/django/django/pull/7436.
     def _cleaning_debug(self):
         testMethod = getattr(self, self._testMethodName)
         skipped = getattr(self.__class__, "__unittest_skip__", False) or getattr(
@@ -536,6 +537,7 @@ def _django_setup_unittest(request, django_db_blocker):
         if not skipped:
             self._post_teardown()
 
+    orig_debug = cls.debug
     cls.debug = _cleaning_debug
 
     with django_db_blocker.unblock():
@@ -550,6 +552,8 @@ def _django_setup_unittest(request, django_db_blocker):
             cls.tearDownClass()
         else:
             yield
+
+    cls.debug = orig_debug
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -456,3 +456,34 @@ def test_pdb_enabled(django_testdir):
 
     result = django_testdir.runpytest_subprocess("-v", "--pdb")
     assert result.ret == 0
+
+
+def test_debug_restored(django_testdir):
+    django_testdir.create_test_module(
+        """
+        from django.test import TestCase
+
+        pre_setup_count = 0
+
+
+        class TestClass1(TestCase):
+
+            def test_method(self):
+                pass
+
+
+        class TestClass2(TestClass1):
+
+            def _pre_setup(self):
+                global pre_setup_count
+                pre_setup_count += 1
+                super(TestClass2, self)._pre_setup()
+
+            def test_method(self):
+                assert pre_setup_count == 1
+    """
+    )
+
+    result = django_testdir.runpytest_subprocess("--pdb")
+    result.stdout.fnmatch_lines(["*= 2 passed in *"])
+    assert result.ret == 0


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-django/issues/769.