### PR TITLE
Unblock DB in case of error for reports

### DIFF
--- a/tests/test_db_access_in_repr.py
+++ b/tests/test_db_access_in_repr.py
@@ -1,0 +1,27 @@
+
+
+def test_db_access_with_repr_in_report(django_testdir):
+    django_testdir.create_test_module(
+        """
+        import pytest
+
+        from .app.models import Item
+
+        def test_via_db_blocker(django_db_setup, django_db_blocker):
+            with django_db_blocker.unblock():
+                Item.objects.get(name='This one is not there')
+
+        def test_via_db_fixture(db):
+            Item.objects.get(name='This one is not there')
+    """
+    )
+
+    result = django_testdir.runpytest_subprocess("--tb=short")
+    result.stdout.fnmatch_lines([
+        "tpkg/test_the_test.py FF",
+        "E   tpkg.app.models.Item.DoesNotExist: Item matching query does not exist.",
+        "E   tpkg.app.models.Item.DoesNotExist: Item matching query does not exist.",
+        "* 2 failed in *",
+    ])
+    assert "INTERNALERROR" not in str(result.stdout) + str(result.stderr)
+    assert result.ret == 1

--- a/tests/test_db_access_in_repr.py
+++ b/tests/test_db_access_in_repr.py
@@ -16,10 +16,12 @@ def test_db_access_with_repr_in_report(django_testdir):
     """
     )
 
-    result = django_testdir.runpytest_subprocess("--tb=short")
+    result = django_testdir.runpytest_subprocess("--tb=auto")
     result.stdout.fnmatch_lines([
         "tpkg/test_the_test.py FF",
         "E   *DoesNotExist: Item matching query does not exist.",
+        "tpkg/test_the_test.py:8: ",
+        "self = <QuerySet []>, args = (), kwargs = {'name': 'This one is not there'}",
         "E   *DoesNotExist: Item matching query does not exist.",
         "* 2 failed in *",
     ])

--- a/tests/test_db_access_in_repr.py
+++ b/tests/test_db_access_in_repr.py
@@ -19,8 +19,8 @@ def test_db_access_with_repr_in_report(django_testdir):
     result = django_testdir.runpytest_subprocess("--tb=short")
     result.stdout.fnmatch_lines([
         "tpkg/test_the_test.py FF",
-        "E   tpkg.app.models.Item.DoesNotExist: Item matching query does not exist.",
-        "E   tpkg.app.models.Item.DoesNotExist: Item matching query does not exist.",
+        "E   *DoesNotExist: Item matching query does not exist.",
+        "E   *DoesNotExist: Item matching query does not exist.",
         "* 2 failed in *",
     ])
     assert "INTERNALERROR" not in str(result.stdout) + str(result.stderr)


### PR DESCRIPTION
This mainly works around pytest causing an INTERNALERROR for when using
`repr()` on the `pytest.fail.Exception` that is used when the DB is
blocked.

While this will be fixed via
https://github.com/pytest-dev/pytest/pull/6047 likely, it might be good
to have this anyway (also for older pytest versions).

On the other hand this might cause the DB to be accessed/changed then,
which might show different results from when the test failed due to
this?!

Fixes https://github.com/pytest-dev/pytest-django/issues/713.
Fixes https://github.com/pytest-dev/pytest-django/issues/341.