### PR TITLE
DB blocker: use RuntimeError instead of pytest.fail

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -777,7 +777,7 @@ class _DatabaseBlocker(object):
     def _blocking_wrapper(*args, **kwargs):
         __tracebackhide__ = True
         __tracebackhide__  # Silence pyflakes
-        pytest.fail(
+        raise RuntimeError(
             "Database access not allowed, "
             'use the "django_db" mark, or the '
             '"db" or "transactional_db" fixtures to enable it.'

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -16,17 +16,17 @@ def db_supports_reset_sequences():
 
 
 def test_noaccess():
-    with pytest.raises(pytest.fail.Exception):
+    with pytest.raises(RuntimeError):
         Item.objects.create(name="spam")
-    with pytest.raises(pytest.fail.Exception):
+    with pytest.raises(RuntimeError):
         Item.objects.count()
 
 
 @pytest.fixture
 def noaccess():
-    with pytest.raises(pytest.fail.Exception):
+    with pytest.raises(RuntimeError):
         Item.objects.create(name="spam")
-    with pytest.raises(pytest.fail.Exception):
+    with pytest.raises(RuntimeError):
         Item.objects.count()
 
 
@@ -254,7 +254,7 @@ def test_unittest_interaction(django_testdir):
             "*test_db_access_2 FAILED*",
             "*test_db_access_3 FAILED*",
             "*ERROR at setup of TestCase_setupClass.test_db_access_1*",
-            '*Failed: Database access not allowed, use the "django_db" mark, '
+            '*RuntimeError: Database access not allowed, use the "django_db" mark, '
             'or the "db" or "transactional_db" fixtures to enable it.',
         ]
     )
@@ -274,7 +274,7 @@ class Test_database_blocking:
         result = django_testdir.runpytest_subprocess("-v")
         result.stderr.fnmatch_lines(
             [
-                '*Failed: Database access not allowed, use the "django_db" mark, '
+                '*RuntimeError: Database access not allowed, use the "django_db" mark, '
                 'or the "db" or "transactional_db" fixtures to enable it.*'
             ]
         )
@@ -290,7 +290,7 @@ class Test_database_blocking:
         result = django_testdir.runpytest_subprocess("-v")
         result.stdout.fnmatch_lines(
             [
-                '*Failed: Database access not allowed, use the "django_db" mark, '
+                '*RuntimeError: Database access not allowed, use the "django_db" mark, '
                 'or the "db" or "transactional_db" fixtures to enable it.'
             ]
         )

--- a/tests/test_db_access_in_repr.py
+++ b/tests/test_db_access_in_repr.py
@@ -1,0 +1,29 @@
+
+
+def test_db_access_with_repr_in_report(django_testdir):
+    django_testdir.create_test_module(
+        """
+        import pytest
+
+        from .app.models import Item
+
+        def test_via_db_blocker(django_db_setup, django_db_blocker):
+            with django_db_blocker.unblock():
+                Item.objects.get(name='This one is not there')
+
+        def test_via_db_fixture(db):
+            Item.objects.get(name='This one is not there')
+    """
+    )
+
+    result = django_testdir.runpytest_subprocess("--tb=auto")
+    result.stdout.fnmatch_lines([
+        "tpkg/test_the_test.py FF",
+        "E   *DoesNotExist: Item matching query does not exist.",
+        "tpkg/test_the_test.py:8: ",
+        'self = *RuntimeError*Database access not allowed*',
+        "E   *DoesNotExist: Item matching query does not exist.",
+        "* 2 failed in *",
+    ])
+    assert "INTERNALERROR" not in str(result.stdout) + str(result.stderr)
+    assert result.ret == 1

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -219,7 +219,7 @@ def test_database_name():
 
 
 def test_database_noaccess():
-    with pytest.raises(pytest.fail.Exception):
+    with pytest.raises(RuntimeError):
         Item.objects.count()
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -607,7 +607,7 @@ class Test_django_db_blocker:
     def test_block_manually(self, django_db_blocker):
         try:
             django_db_blocker.block()
-            with pytest.raises(pytest.fail.Exception):
+            with pytest.raises(RuntimeError):
                 Item.objects.exists()
         finally:
             django_db_blocker.restore()
@@ -615,7 +615,7 @@ class Test_django_db_blocker:
     @pytest.mark.django_db
     def test_block_with_block(self, django_db_blocker):
         with django_db_blocker.block():
-            with pytest.raises(pytest.fail.Exception):
+            with pytest.raises(RuntimeError):
                 Item.objects.exists()
 
     def test_unblock_manually(self, django_db_blocker):


### PR DESCRIPTION
pytest fails to handle `pytest.fail.Exception` when raised in `repr`, resulting
in confusing "INTERNALERROR" messages, hiding the real failure (since it
happens during reporting).

This changes pytest-django to raise `RuntimeError` instead.

While this will be fixed via
https://github.com/pytest-dev/pytest/pull/6047 likely, it might be good
to have this anyway (also for older pytest versions).

Fixes https://github.com/pytest-dev/pytest-django/issues/713
Fixes https://github.com/pytest-dev/pytest-django/issues/341