### PR TITLE
Don't break --failed-first when re-ordering tests

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -415,6 +415,7 @@ def pytest_runtest_setup(item):
             _disable_class_methods(item.cls)
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(items):
     def get_order_number(test):
         marker_db = test.get_closest_marker('django_db')


### PR DESCRIPTION
Pytest-django 3.5.0 attempts to run tests in the same order as Django:
Issue #223, Commit 5a79fba3705376c3f89f5a9e26b8244937d61768

Pytest itself can re-order tests to prioritize previously failed tests
(`--failed-first`), incremental runs of the test suite (`--stepwise`), etc.
However, pytest-django's re-ordering clobbers pytest's, which can break
those options as reported in #819.

By applying the `@pytest.hookimpl(tryfirst=True)` decorator to
`pytest_collection_modifyitems()`, pytest-django's re-ordering happens
first, and does not clobber the later re-ordering performed by pytest.

Fixes #819