### PR TITLE
Better order tests when mixing transactional tests and Django test classes

### DIFF
--- a/tests/test_db_setup.py
+++ b/tests/test_db_setup.py
@@ -33,7 +33,9 @@ def test_db_order(django_testdir):
     """Test order in which tests are being executed."""
 
     django_testdir.create_test_module('''
+        from unittest import TestCase
         import pytest
+        from django.test import SimpleTestCase, TestCase as DjangoTestCase, TransactionTestCase
 
         from .app.models import Item
 
@@ -50,14 +52,34 @@ def test_db_order(django_testdir):
         @pytest.mark.django_db
         def test_run_first_decorator():
             pass
+
+        class MyTestCase(TestCase):
+            def test_run_last_test_case(self):
+                pass
+
+        class MySimpleTestCase(SimpleTestCase):
+            def test_run_last_simple_test_case(self):
+                pass
+
+        class MyDjangoTestCase(DjangoTestCase):
+            def test_run_first_django_test_case(self):
+                pass
+
+        class MyTransactionTestCase(TransactionTestCase):
+            def test_run_second_transaction_test_case(self):
+                pass
     ''')
     result = django_testdir.runpytest_subprocess('-v', '-s')
     assert result.ret == 0
     result.stdout.fnmatch_lines([
         "*test_run_first_fixture*",
         "*test_run_first_decorator*",
+        "*test_run_first_django_test_case*",
         "*test_run_second_decorator*",
         "*test_run_second_fixture*",
+        "*test_run_second_transaction_test_case*",
+        "*test_run_last_test_case*",
+        "*test_run_last_simple_test_case*",
     ])
 
 


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest-django/issues/827

- [x] Edited `test_db_order` to add Django test classes (test was failing, as expected)
- [x] Changed `pytest_collection_modifyitems` to take Django classes into consideration (test is now passing)
- [x] Fix `test_django_not_loaded_without_settings`

### About `test_django_not_loaded_without_settings`

`test_django_not_loaded_without_settings` is now failing. That's not a surprise since we import `django` in `plugin.py`. Moving the import in the `pytest_collection_modifyitems` does not work either (since the function is run when collecting tests :upside_down_face: )
I tried looking for eg. a class attribute unique to `TestCase` or `TransactionTestCase` but I didn't find any (not that it would be a great solution :\)

Another solution could be to dynamically import django in `pytest_collection_modifyitems` after checking for `DJANGO_SETTINGS_MODULE`? Please advise if you have other / better ideas :)

I ended up doing the dynamic import, taking inspiration from other places where `django_settings_is_configured` is used. It's a bit ugly but it does the job :O Improvements welcome :)