### PR TITLE
Docs - explain how to get a db connection

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -231,7 +231,10 @@ is configured to be in the containing Django project.
 This fixture will ensure the Django database is set up.  Only
 required for fixtures that want to use the database themselves.  A
 test function should normally use the ``pytest.mark.django_db``
-mark to signal it needs the database.
+mark to signal it needs the database. This fixture does
+not return a database connection object. When you need a Django 
+database connection or cursor, import it from Django using
+``from django.db import connection``.
 
 ``transactional_db``
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I was thinking that I could use the `db` fixture to access a database connection object within a test. However, the `db` fixture returns None. 

This documentation update makes it clear that the `db` fixture does not return an object, and explains that users should use from `django.db import connection` instead.

Reference:
See [this comment](https://github.com/pytest-dev/pytest-django/issues/338#issuecomment-227402089) on issue #338.