### PR TITLE
Correct typo in database docs

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -401,7 +401,7 @@ Use the same database for all xdist processes
 """""""""""""""""""""""""""""""""""""""""""""
 
 By default, each xdist process gets its own database to run tests on. This is
-needed to have transactional tests that does not interfere with eachother.
+needed to have transactional tests that does not interfere with each other.
 
 If you instead want your tests to use the same database, override the
 :fixture:`django_db_modify_db_settings` to not do anything. Put this in

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -401,7 +401,7 @@ Use the same database for all xdist processes
 """""""""""""""""""""""""""""""""""""""""""""
 
 By default, each xdist process gets its own database to run tests on. This is
-needed to have transactional tests that does not interfere with each other.
+needed to have transactional tests that do not interfere with each other.
 
 If you instead want your tests to use the same database, override the
 :fixture:`django_db_modify_db_settings` to not do anything. Put this in


### PR DESCRIPTION
Correcting a minor typo on the https://pytest-django.readthedocs.io/en/latest/database.html page.