### PR TITLE
Make admin_user & admin_client fixtures compatible with custom user models

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -291,11 +291,12 @@ def admin_user(db, django_user_model, django_username_field):
     try:
         user = UserModel._default_manager.get(**{username_field: username})
     except UserModel.DoesNotExist:
-        extra_fields = {}
-        if username_field not in ("username", "email"):
-            extra_fields[username_field] = "admin"
         user = UserModel._default_manager.create_superuser(
-            username, "admin@example.com", "password", **extra_fields
+            **{
+                username_field: username,
+                "email": "admin@example.com",
+                "password": "password",
+            }
         )
     return user
 
@@ -306,7 +307,7 @@ def admin_client(db, admin_user):
     from django.test.client import Client
 
     client = Client()
-    client.login(username=admin_user.username, password="password")
+    client.login(username=admin_user.get_username(), password="password")
     return client
 
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -240,7 +240,7 @@ def _get_boolean_value(x, name, default=None):
     except KeyError:
         raise ValueError(
             "{} is not a valid value for {}. "
-            "It must be one of {}." % (x, name, ", ".join(possible_values.keys()))
+            "It must be one of {}.".format(x, name, ", ".join(possible_values.keys()))
         )
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -503,15 +503,40 @@ class TestLiveServer:
 def test_custom_user_model(django_testdir, username_field):
     django_testdir.create_app_file(
         """
-        from django.contrib.auth.models import AbstractUser
+        from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
         from django.db import models
 
-        class MyCustomUser(AbstractUser):
-            identifier = models.CharField(unique=True, max_length=100)
+        class MyCustomUserManager(BaseUserManager):
+            def create_user(self, {username_field}, password=None, **extra_fields):
+                extra_fields.setdefault('is_staff', False)
+                extra_fields.setdefault('is_superuser', False)
+                user = self.model({username_field}={username_field}, **extra_fields)
+                user.set_password(password)
+                user.save()
+                return user
 
-            USERNAME_FIELD = '%s'
-        """
-        % (username_field),
+            def create_superuser(self, {username_field}, password=None, **extra_fields):
+                extra_fields.setdefault('is_staff', True)
+                extra_fields.setdefault('is_superuser', True)
+                return self.create_user(
+                    {username_field}={username_field},
+                    password=password,
+                    **extra_fields
+                )
+
+        class MyCustomUser(AbstractBaseUser, PermissionsMixin):
+            email = models.EmailField(max_length=254, unique=True)
+            identifier = models.CharField(unique=True, max_length=100)
+            is_staff = models.BooleanField(
+                'staff status',
+                default=False,
+                help_text='Designates whether the user can log into this admin site.'
+            )
+
+            objects = MyCustomUserManager()
+
+            USERNAME_FIELD = '{username_field}'
+        """.format(username_field=username_field),
         "models.py",
     )
     django_testdir.create_app_file(
@@ -573,19 +598,13 @@ class Migration(migrations.Migration):
                 ('password', models.CharField(max_length=128, verbose_name='password')),
                 ('last_login', models.DateTimeField(null=True, verbose_name='last login', blank=True)),
                 ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
-                ('username', models.CharField(error_messages={'unique': 'A user with that username already exists.'}, max_length=30, validators=[django.core.validators.RegexValidator(r'^[\\w.@+-]+$', 'Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters.', 'invalid')], help_text='Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only.', unique=True, verbose_name='username')),
-                ('first_name', models.CharField(max_length=30, verbose_name='first name', blank=True)),
-                ('last_name', models.CharField(max_length=30, verbose_name='last name', blank=True)),
-                ('email', models.EmailField(max_length=254, verbose_name='email address', blank=True)),
+                ('email', models.EmailField(error_messages={'unique': 'A user with that email address already exists.'}, max_length=254, unique=True, verbose_name='email address')),
                 ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
-                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
-                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
                 ('identifier', models.CharField(unique=True, max_length=100)),
                 ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups')),
                 ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
             ],
             options={
-                'abstract': False,
                 'verbose_name': 'user',
                 'verbose_name_plural': 'users',
             },

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -616,7 +616,7 @@ class Migration(migrations.Migration):
     )
 
     result = django_testdir.runpytest_subprocess("-s")
-    result.stdout.fnmatch_lines(["* 1 passed in*"])
+    result.stdout.fnmatch_lines(["* 1 passed*"])
     assert result.ret == 0
 
 


### PR DESCRIPTION
Using the `admin_client` fixture with a custom user model that doesn't have a username field doesn't work currently. The fixture assumes that the user model always has a `username` field present. For this case, Django has `User.USERNAME_FIELD` and `User.get_username()`. 

Unfortunately, the existing test didn't catch this issue because a custom user model _with_ `User.username` is used. 

This pull request changes the test setup to use a custom user without `username` and makes `admin_client` use `User.get_username()`.

There are a few merge requests and issues about this problem already. I hope this one meets the requirements to be merged. If not, please let me know and I see what I can do.  

- https://github.com/pytest-dev/pytest-django/pull/246
- https://github.com/pytest-dev/pytest-django/pull/484
- https://github.com/pytest-dev/pytest-django/pull/748
- https://github.com/pytest-dev/pytest-django/issues/457