### PR TITLE
Fix incorrect sentence syntax.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -42,7 +42,7 @@ after installation, there is nothing more to configure.
 Step 2: Point pytest to your Django settings
 --------------------------------------------
 
-You need to tell pytest which Django settings that should be used for test
+You need to tell pytest which Django settings should be used for test
 runs. The easiest way to achieve this is to create a pytest configuration file
 with this information.
 


### PR DESCRIPTION
In this sentence:  "You need to tell pytest which Django settings that should be used for test
runs." The word "that" should not be used.

The correct wording should be: "You need to tell pytest which Django settings should be used for test
runs."