### PR TITLE
Run tests against Django 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ jobs:
       env: TOXENV=py37-dj22-sqlite-xdist-coverage
     - python: 3.8
       env: TOXENV=py38-dj30-sqlite-xdist-coverage
+    - python: 3.8
+      env: TOXENV=py38-dj31-sqlite-xdist-coverage
 
     # Explicitly test (older) pytest 4.1.
     - python: 3.7

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -240,7 +240,7 @@ def _get_boolean_value(x, name, default=None):
     except KeyError:
         raise ValueError(
             "{} is not a valid value for {}. "
-            "It must be one of {}." % (x, name, ", ".join(possible_values.keys()))
+            "It must be one of {}.".format(x, name, ", ".join(possible_values.keys()))
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
                  'Framework :: Django :: 2.1',
                  'Framework :: Django :: 2.2',
                  'Framework :: Django :: 3.0',
+                 'Framework :: Django :: 3.1',
                  'Intended Audience :: Developers',
                  'License :: OSI Approved :: BSD License',
                  'Operating System :: OS Independent',

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -516,10 +516,16 @@ def test_custom_user_model(django_testdir, username_field):
     )
     django_testdir.create_app_file(
         """
-        from django.conf.urls import url
         from tpkg.app import views
 
-        urlpatterns = [url(r'admin-required/', views.admin_required_view)]
+        try:
+            from django.urls import path
+        except ImportError:
+            from django.conf.urls import url
+
+            urlpatterns = [url(r'admin-required/', views.admin_required_view)]
+        else:
+            urlpatterns = [path('admin-required/', views.admin_required_view)]
         """,
         "urls.py",
     )

--- a/tests/test_manage_py_scan.py
+++ b/tests/test_manage_py_scan.py
@@ -116,7 +116,7 @@ def test_django_project_found_invalid_settings_version(django_testdir, monkeypat
     """Invalid DSM should not cause an error with --help or --version."""
     monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "DOES_NOT_EXIST")
 
-    result = django_testdir.runpytest_subprocess("django_project_root", "--version")
+    result = django_testdir.runpytest_subprocess("django_project_root", "--version", "--version")
     assert result.ret == 0
     result.stderr.fnmatch_lines(["*This is pytest version*"])
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py37-dj{30,22,21,20,111}-postgres
-    py36-dj{30,22,21,20,111,110,19,18}-postgres
+    py37-dj{31,30,22,21,20,111}-postgres
+    py36-dj{31,30,22,21,20,111,110,19,18}-postgres
     py35-dj{22,21,20,111,110,19,18}-postgres
     py34-dj{20,111,110}-postgres
     py27-dj{111,110}-{mysql_innodb,mysql_myisam,postgres}
@@ -12,8 +12,9 @@ envlist =
 extras = testing
 deps =
     djmaster: https://github.com/django/django/archive/master.tar.gz
-    dj30: Django>=3.0a1,<3.1
-    dj22: Django>=2.2a1,<2.3
+    dj31: Django>=3.1rc1,<3.2
+    dj30: Django>=3.0,<3.1
+    dj22: Django>=2.2,<2.3
     dj21: Django>=2.1,<2.2
     dj20: Django>=2.0,<2.1
     dj111: Django>=1.11,<1.12


### PR DESCRIPTION
Django 3.1 is due on Monday 2020-08-03 if there isn't another RC release.
https://code.djangoproject.com/wiki/Version3.1Roadmap

This PR also includes two commits with unrelated changes.  They are necessary for the tests to pass.  (They are necessary to let the baseline stage pass on travis and actually run the new job.)