### PR TITLE
Update setup_databases call to handle >3.1

### DIFF
--- a/pytest_django/compat.py
+++ b/pytest_django/compat.py
@@ -13,3 +13,12 @@ except ImportError:
         _DiscoverRunner(verbosity=verbosity, interactive=False).teardown_databases(
             db_cfg
         )
+
+
+# Import NullTimeKeeper from Django > 3.1 for setup_databases call -
+# fix for https://github.com/pytest-dev/pytest-django/issues/858
+try:
+    from django.test.utils import NullTimeKeeper
+    setup_databases_args = {"time_keeper": NullTimeKeeper()}
+except ImportError:
+    setup_databases_args = {}

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -91,9 +91,7 @@ def django_db_setup(
     django_db_modify_db_settings,
 ):
     """Top level fixture to ensure test databases are available"""
-    from .compat import setup_databases, teardown_databases
-
-    setup_databases_args = {}
+    from .compat import setup_databases, teardown_databases, setup_databases_args
 
     if not django_db_use_migrations:
         _disable_native_migrations()


### PR DESCRIPTION
Fixes #858 

---

A breaking change in the current master on Django has added a mandatory `time_keeper` kwarg to the `django.test.utils.setup_databases` function signature. This is a `TimeKeeper` object which is used to record how long it takes to setup test databases. It is used internally by the Django tests themselves. A `NullTimeKeeper` object is available if timings are not required. I have used the `NullTimeKeeper` in this PR (as I don't think setup timing is a core pytest requirement?)

There are no additional tests for this change, as its main impact is in fixing the existing test suite. There should be a reduction in the number of current failures on `py*_djmaster` builds. I currently get these failures when running `make test` locally against the latest master of Django:

```
================================================================================================================= short test summary info =================================================================================================================
ERROR tests/test_asserts.py::test_sanity - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_transactions_disabled - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_django_db_reset_sequences_fixture - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixturesAllOrder::test_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseMarker::test_access - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseMarker::test_clean_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseMarker::test_transactions_disabled - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseMarker::test_transactions_disabled_explicit - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseMarker::test_reset_sequences_disabled - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseMarker::test_reset_sequences_enabled - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_environment.py::TestDirectAccessWorksForDjangoTestCase::test_one - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_environment.py::TestDirectAccessWorksForDjangoTestCase::test_two - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_environment.py::test_database_rollback - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_environment.py::test_database_rollback_again - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_environment.py::test_database_name - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_environment.py::test_clear_site_cache[site1] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_environment.py::test_clear_site_cache[site2] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_environment.py::test_clear_site_cache_check_site_cache_size[site1] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_environment.py::test_clear_site_cache_check_site_cache_size[site2] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::test_admin_client - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::test_admin_client_no_db_marker - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::test_admin_user - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::test_admin_user_no_db_marker - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::test_django_assert_num_queries_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::test_django_assert_max_num_queries_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::test_django_assert_num_queries_db_connection - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::test_django_assert_num_queries_output_info - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_fixture_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_item_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::Test_django_db_blocker::test_block_manually - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::Test_django_db_blocker::test_block_with_block - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_unittest.py::TestFixtures::test_fixtures - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_unittest.py::TestFixtures::test_fixtures_again - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_unittest.py::TestSetup::test_count - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_unittest.py::TestSetup::test_count_again - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_unittest.py::TestFixturesWithSetup::test_count - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_unittest.py::TestFixturesWithSetup::test_count_again - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_unittest.py::TestCaseWithDbFixture::test_simple - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_unittest.py::TestCaseWithTrDbFixture::test_simple - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_transactions_enabled - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixturesAllOrder::test_trans - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixturesAllOrder::test_db_trans - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixturesAllOrder::test_trans_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixturesAllOrder::test_reset_sequences - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseMarker::test_transactions_enabled - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::test_django_assert_num_queries_transactional_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_fixture_transactional_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_item_transactional_db - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_access[db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_access[transactional_db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_access[django_db_reset_sequences] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_clean_db[db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_clean_db[transactional_db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_clean_db[django_db_reset_sequences] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_transactions_enabled_via_reset_seq - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_mydb[db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_mydb[transactional_db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_mydb[django_db_reset_sequences] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_fixture_clean[db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_fixture_clean[transactional_db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_fixture_clean[django_db_reset_sequences] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_fin[db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_fin[transactional_db] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_database.py::TestDatabaseFixtures::test_fin[django_db_reset_sequences] - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_url - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_change_settings - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_transactions - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_db_changes_visibility - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_item - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
ERROR tests/test_fixtures.py::TestLiveServer::test_serve_static_dj17_without_staticfiles_app - TypeError: setup_databases() missing 1 required keyword-only argument: 'time_keeper'
```
