### PR TITLE
admin_user - get user by natural key

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -287,6 +287,10 @@ def admin_user(db, django_user_model, django_username_field):
     username = "admin@example.com" if username_field == "email" else "admin"
 
     try:
+        # The default behavior of `get_by_natural_key()` is to look up by `username_field`.
+        # However the user model is free to override it with any sort of custom behavior.
+        # The Django authentication backend already assumes the lookup is by username,
+        # so we can assume so as well.
         user = UserModel._default_manager.get_by_natural_key(username)
     except UserModel.DoesNotExist:
         extra_fields = {}

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -287,7 +287,7 @@ def admin_user(db, django_user_model, django_username_field):
     username = "admin@example.com" if username_field == "email" else "admin"
 
     try:
-        user = UserModel._default_manager.get(**{username_field: username})
+        user = UserModel._default_manager.get_by_natural_key(username)
     except UserModel.DoesNotExist:
         extra_fields = {}
         if username_field not in ("username", "email"):


### PR DESCRIPTION
Using manager's `get_by_natural_key` should be preferred for getting users as oftentimes this method is customized by developers