### PR TITLE
Force login admin user in admin_client

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -158,14 +158,18 @@ Example
         response = client.get('/')
         assert response.content == 'Foobar'
 
-To use `client` as an authenticated standard user, call its `login()` method before accessing a URL:
+To use `client` as an authenticated standard user, call its `force_login()` or
+`login()` method before accessing a URL:
 
 ::
 
     def test_with_authenticated_client(client, django_user_model):
         username = "user1"
         password = "bar"
-        django_user_model.objects.create_user(username=username, password=password)
+        user = django_user_model.objects.create_user(username=username, password=password)
+        # Use this:
+        client.force_login(user)
+        # Or this:
         client.login(username=username, password=password)
         response = client.get('/private')
         assert response.content == 'Protected Area'

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -304,7 +304,7 @@ def admin_client(db, admin_user):
     from django.test.client import Client
 
     client = Client()
-    client.login(username=admin_user.username, password="password")
+    client.force_login(admin_user)
     return client
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -49,6 +49,17 @@ def test_admin_client_no_db_marker(admin_client):
     assert force_str(resp.content) == "You are an admin"
 
 
+# For test below.
+@pytest.fixture
+def existing_admin_user(django_user_model):
+    return django_user_model._default_manager.create_superuser('admin', None, None)
+
+
+def test_admin_client_existing_user(db, existing_admin_user, admin_user, admin_client):
+    resp = admin_client.get("/admin-required/")
+    assert force_str(resp.content) == "You are an admin"
+
+
 @pytest.mark.django_db
 def test_admin_user(admin_user, django_user_model):
     assert isinstance(admin_user, django_user_model)


### PR DESCRIPTION
Fixes #513. Re-spin of #517 with some adjustments.

This bypasses the username+password entirely; they cause complications and may fail.