### PR TITLE
Make admin_user & admin_client fixtures compatible with custom user models

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -293,11 +293,12 @@ def admin_user(db, django_user_model, django_username_field):
         # so we can assume so as well.
         user = UserModel._default_manager.get_by_natural_key(username)
     except UserModel.DoesNotExist:
-        extra_fields = {}
-        if username_field not in ("username", "email"):
-            extra_fields[username_field] = "admin"
         user = UserModel._default_manager.create_superuser(
-            username, "admin@example.com", "password", **extra_fields
+            **{
+                "email": "admin@example.com",
+                "password": "password",
+                username_field: username,
+            }
         )
     return user
 

--- a/pytest_django_test/settings_mysql_innodb.py
+++ b/pytest_django_test/settings_mysql_innodb.py
@@ -2,6 +2,7 @@ from os import environ
 
 from .settings_base import *  # noqa: F401 F403
 
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
@@ -9,6 +10,13 @@ DATABASES = {
         "USER": environ.get("TEST_DB_USER", "root"),
         "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
         "HOST": environ.get("TEST_DB_HOST", "localhost"),
-        "OPTIONS": {"init_command": "SET default_storage_engine=InnoDB"},
-    }
+        "OPTIONS": {
+            "init_command": "SET default_storage_engine=InnoDB",
+            "charset": "utf8mb4",
+        },
+        "TEST": {
+            "CHARSET": "utf8mb4",
+            "COLLATION": "utf8mb4_unicode_ci",
+        },
+    },
 }

--- a/pytest_django_test/settings_mysql_myisam.py
+++ b/pytest_django_test/settings_mysql_myisam.py
@@ -2,6 +2,7 @@ from os import environ
 
 from .settings_base import *  # noqa: F401 F403
 
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
@@ -9,6 +10,13 @@ DATABASES = {
         "USER": environ.get("TEST_DB_USER", "root"),
         "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
         "HOST": environ.get("TEST_DB_HOST", "localhost"),
-        "OPTIONS": {"init_command": "SET default_storage_engine=MyISAM"},
-    }
+        "OPTIONS": {
+            "init_command": "SET default_storage_engine=MyISAM",
+            "charset": "utf8mb4",
+        },
+        "TEST": {
+            "CHARSET": "utf8mb4",
+            "COLLATION": "utf8mb4_unicode_ci",
+        },
+    },
 }

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -483,15 +483,40 @@ class TestLiveServer:
 def test_custom_user_model(django_testdir, username_field):
     django_testdir.create_app_file(
         """
-        from django.contrib.auth.models import AbstractUser
+        from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
         from django.db import models
 
-        class MyCustomUser(AbstractUser):
-            identifier = models.CharField(unique=True, max_length=100)
+        class MyCustomUserManager(BaseUserManager):
+            def create_user(self, {username_field}, password=None, **extra_fields):
+                extra_fields.setdefault('is_staff', False)
+                extra_fields.setdefault('is_superuser', False)
+                user = self.model({username_field}={username_field}, **extra_fields)
+                user.set_password(password)
+                user.save()
+                return user
 
-            USERNAME_FIELD = '%s'
-        """
-        % (username_field),
+            def create_superuser(self, {username_field}, password=None, **extra_fields):
+                extra_fields.setdefault('is_staff', True)
+                extra_fields.setdefault('is_superuser', True)
+                return self.create_user(
+                    {username_field}={username_field},
+                    password=password,
+                    **extra_fields
+                )
+
+        class MyCustomUser(AbstractBaseUser, PermissionsMixin):
+            email = models.EmailField(max_length=100, unique=True)
+            identifier = models.CharField(unique=True, max_length=100)
+            is_staff = models.BooleanField(
+                'staff status',
+                default=False,
+                help_text='Designates whether the user can log into this admin site.'
+            )
+
+            objects = MyCustomUserManager()
+
+            USERNAME_FIELD = '{username_field}'
+        """.format(username_field=username_field),
         "models.py",
     )
     django_testdir.create_app_file(
@@ -551,19 +576,13 @@ class Migration(migrations.Migration):
                 ('password', models.CharField(max_length=128, verbose_name='password')),
                 ('last_login', models.DateTimeField(null=True, verbose_name='last login', blank=True)),
                 ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
-                ('username', models.CharField(error_messages={'unique': 'A user with that username already exists.'}, max_length=30, validators=[django.core.validators.RegexValidator(r'^[\\w.@+-]+$', 'Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters.', 'invalid')], help_text='Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only.', unique=True, verbose_name='username')),
-                ('first_name', models.CharField(max_length=30, verbose_name='first name', blank=True)),
-                ('last_name', models.CharField(max_length=30, verbose_name='last name', blank=True)),
-                ('email', models.EmailField(max_length=254, verbose_name='email address', blank=True)),
+                ('email', models.EmailField(error_messages={'unique': 'A user with that email address already exists.'}, max_length=100, unique=True, verbose_name='email address')),
                 ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
-                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
-                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
                 ('identifier', models.CharField(unique=True, max_length=100)),
                 ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups')),
                 ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
             ],
             options={
-                'abstract': False,
                 'verbose_name': 'user',
                 'verbose_name_plural': 'users',
             },


### PR DESCRIPTION
Replaces PR #843 with some minor updates. Commits by @jnns.

---

Using the `admin_client` fixture with a custom user model that doesn't have a username field doesn't work currently. The fixture assumes that the user model always has a `username` field present. For this case, Django has `User.USERNAME_FIELD` and `User.get_username()`. 

Unfortunately, the existing test didn't catch this issue because a custom user model _with_ `User.username` is used. 

This pull request changes the test setup to use a custom user without `username` and makes `admin_client` use `User.get_username()`.

There are a few merge requests and issues about this problem already. I hope this one meets the requirements to be merged. If not, please let me know and I see what I can do.  

Closes #246
Closes #484
Closes #748
Fixes #457