### PR TITLE
[MINOR] add opt-in multi-database support for db fixtures

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -71,6 +71,7 @@ other than ``default`` by adding a special key to your database test configurati
 in your django settings.
 
 for example::
+
     DATABASES = {
         "default": {
             # ... normal default settings
@@ -82,6 +83,7 @@ for example::
             }
         }
     }
+
 
 With that database configuration in your test environment, tests that depend on the
 ``db`` or ``transactional_db`` fixtures can make changes in the "secondary" database

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -66,21 +66,31 @@ select using an argument to the ``django_db`` mark::
 Tests requiring multiple databases
 ----------------------------------
 
-Currently ``pytest-django`` does not specifically support Django's
-multi-database support.
+You can configure ``pytest-django`` to create transactions (or cleanup) databases
+other than ``default`` by adding a special key to your database test configuration
+in your django settings.
 
-You can however use normal :class:`~django.test.TestCase` instances to use its
+for example::
+    DATABASES = {
+        "default": {
+            # ... normal default settings
+        },
+        "secondary": {
+            # ... engine settings and so forth
+            "TEST": {
+                "PYTEST_DJANGO_ALLOW_TRANSACTIONS": True
+            }
+        }
+    }
+
+With that database configuration in your test environment, tests that depend on the
+``db`` or ``transactional_db`` fixtures can make changes in the "secondary" database
+and have it cleaned up after each test.
+
+You could also use normal :class:`~django.test.TestCase` instances to use its
 :ref:`django:topics-testing-advanced-multidb` support.
 In particular, if your database is configured for replication, be sure to read
 about :ref:`django:topics-testing-primaryreplica`.
-
-If you have any ideas about the best API to support multiple databases
-directly in ``pytest-django`` please get in touch, we are interested
-in eventually supporting this but unsure about simply following
-Django's approach.
-
-See `pull request 431 <https://github.com/pytest-dev/pytest-django/pull/431>`_
-for an idea/discussion to approach this.
 
 ``--reuse-db`` - reuse the testing database between test runs
 --------------------------------------------------------------

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -154,11 +154,6 @@ def _django_db_fixture_helper(
     if transactional_databases:
 
         class MultiDatabaseTransactionTestCase(django_case):
-            # django versions <= 1.8.X don't use `databases` attribute, it's all or nothing
-            # for those versions, django will create a transaction in every db in DATABASES
-            # if multi_db is True
-            # multi_db is not used in newer django versions
-            multi_db = True
             databases = transactional_databases
 
         django_case = MultiDatabaseTransactionTestCase

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -152,15 +152,17 @@ def _django_db_fixture_helper(
     # https://docs.djangoproject.com/en/3.1/topics/testing/tools/#multi-database-support
     transactional_databases = _transactional_databases(settings)
     if transactional_databases:
-        # django versions <= 1.8.X don't use `databases` attribute, it's all or nothing
-        # for those versions, django will create a transaction in every db in DATABASES
-        # if multi_db is True
-        # multi_db is not used in newer django versions
-        django_case.multi_db = True
-        try:
-            django_case.databases = django_case.databases.union(transactional_databases)
-        except AttributeError:
-            django_case.databases = transactional_databases
+
+        class MultiDatabaseTransactionTestCase(django_case):
+            # django versions <= 1.8.X don't use `databases` attribute, it's all or nothing
+            # for those versions, django will create a transaction in every db in DATABASES
+            # if multi_db is True
+            # multi_db is not used in newer django versions
+            multi_db = True
+            databases = transactional_databases
+
+        django_case = MultiDatabaseTransactionTestCase
+        request.config.django_transactional_databases = transactional_databases
 
     test_case = django_case(methodName="__init__")
     test_case._pre_setup()

--- a/pytest_django_test/settings_sqlite.py
+++ b/pytest_django_test/settings_sqlite.py
@@ -5,11 +5,4 @@ DATABASES = {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": "/should_not_be_accessed",
     },
-    "two": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "/should_not_be_accessed_two",
-        "TEST": {
-            "PYTEST_DJANGO_ALLOW_TRANSACTIONS": True
-        }
-    }
 }

--- a/pytest_django_test/settings_sqlite.py
+++ b/pytest_django_test/settings_sqlite.py
@@ -4,5 +4,12 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": "/should_not_be_accessed",
+    },
+    "two": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "/should_not_be_accessed_two",
+        "TEST": {
+            "PYTEST_DJANGO_ALLOW_TRANSACTIONS": True
+        }
     }
 }

--- a/pytest_django_test/settings_sqlite_file.py
+++ b/pytest_django_test/settings_sqlite_file.py
@@ -13,5 +13,12 @@ DATABASES = {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": "/pytest_django_should_never_get_accessed",
         "TEST": {"NAME": _filename},
+    },
+    "secondary": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "/should_not_be_accessed_two",
+        "TEST": {
+            "PYTEST_DJANGO_ALLOW_TRANSACTIONS": True
+        }
     }
 }

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -139,7 +139,10 @@ class TestDatabaseFixtures:
         pass
 
     def test_db_sets_transactions_in_all_configured_connections(self, settings, db):
-        assert all(conn.in_atomic_block for conn in connections.all())
+        assert all(
+            conn.in_atomic_block
+            for conn in connections.all() if conn.features.supports_transactions
+        )
 
     def test_multi_database_true_if_settings_permit_db(self, request, settings, transactional_db):
         transactional_databases = set()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -138,7 +138,10 @@ class TestDatabaseFixtures:
         # Check finalizer has db access (teardown will fail if not)
         pass
 
-    def test_multi_database_true_if_settings_permit_db(self, settings, db):
+    def test_db_sets_transactions_in_all_configured_connections(self, settings, db):
+        assert all(conn.in_atomic_block for conn in connections.all())
+
+    def test_multi_database_true_if_settings_permit_db(self, request, settings, transactional_db):
         transactional_databases = set()
         for label, config in settings.DATABASES.items():
             if config.get("TEST", {}).get("PYTEST_DJANGO_ALLOW_TRANSACTIONS"):
@@ -150,7 +153,8 @@ class TestDatabaseFixtures:
                 "in databases outside of default"
             )
 
-        assert all(conn.in_atomic_block for conn in connections.all())
+        assert {"default", "secondary"} == request.config.django_transactional_databases
+
 
 class TestDatabaseFixturesAllOrder:
     @pytest.fixture


### PR DESCRIPTION
Adds opt-in multi-database support for database fixtures (db, transactional_db) to cleanup in databases other than `default`.

This approach uses a setting in `settings.DATABASES["db_name"]["TEST"]["PYTEST_DJANGO_ALLOW_TRANSACTIONS"]` to determine whether the database fixtures should create a transaction, or cleanup that database after each test. It does this by extending the collection of database names on the relevant django TestCase's `databases` attribute or by setting `multi_db=True` for compatibility with django version <=1.8.x.

TODO:
- [x] update documentation
- [ ] ask maintainers if they'd like these tests to run against other databases and add the DATABASES config if so
- [x] I found #431 and will be adjusting the approach based on the feedback in that PR