### PR TITLE
Add `request.user` to example

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -132,6 +132,10 @@ Example
 
     def test_details(rf, admin):
         request = rf.get('/customer/details')
+        # Remember that when using RequestFactory, the request does not pass
+        # through middleware. If your view expects fields such as request.user
+        # to be set, you need to set them explicitly.
+        # The following line sets request.user to an admin user.
         request.user = admin
         response = my_view(request)
         assert response.status_code == 200

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -130,8 +130,9 @@ Example
 
     from myapp.views import my_view
 
-    def test_details(rf):
+    def test_details(rf, admin):
         request = rf.get('/customer/details')
+        request.user = admin
         response = my_view(request)
         assert response.status_code == 200
 


### PR DESCRIPTION
Newcomers get very confused if `request.user` is not set. I think it makes sense to underline this in the example.