### PR TITLE
Disable atomic durability check on non-transactional tests

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -147,6 +147,12 @@ def _django_db_fixture_helper(
             django_case = ResetSequenceTestCase
     else:
         from django.test import TestCase as django_case
+        from django.db import transaction
+        transaction.Atomic._ensure_durability = False
+
+        def reset_durability():
+            transaction.Atomic._ensure_durability = True
+        request.addfinalizer(reset_durability)
 
     test_case = django_case(methodName="__init__")
     test_case._pre_setup()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,7 +1,8 @@
 import pytest
-from django.db import connection
+from django.db import connection, transaction
 from django.test.testcases import connections_support_transactions
 
+from pytest_django.lazy_django import get_django_version
 from pytest_django_test.app.models import Item
 
 
@@ -137,6 +138,12 @@ class TestDatabaseFixtures:
     def test_fin(self, fin):
         # Check finalizer has db access (teardown will fail if not)
         pass
+
+    @pytest.mark.skipif(get_django_version() < (3, 2), reason="Django >= 3.2 required")
+    def test_durable_transactions(self, all_dbs):
+        with transaction.atomic(durable=True):
+            item = Item.objects.create(name="foo")
+        assert Item.objects.get() == item
 
 
 class TestDatabaseFixturesAllOrder:


### PR DESCRIPTION
Fixes #909