### PR TITLE
Add initial experimental multi database support

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -64,21 +64,25 @@ select using an argument to the ``django_db`` mark::
 Tests requiring multiple databases
 ----------------------------------
 
+.. caution::
+
+    This support is **experimental** and is subject to change without
+    deprecation. We are still figuring out the best way to expose this
+    functionality. If you are using this successfully or unsuccessfully,
+    `let us know <https://github.com/pytest-dev/pytest-django/issues/924>`_!
+
+``pytest-django`` has experimental support for multi-database configurations.
 Currently ``pytest-django`` does not specifically support Django's
-multi-database support.
+multi-database support, using the ``databases`` argument to the
+:py:func:`django_db <pytest.mark.django_db>` mark::
 
-You can however use normal :class:`~django.test.TestCase` instances to use its
-:ref:`django:topics-testing-advanced-multidb` support.
-In particular, if your database is configured for replication, be sure to read
-about :ref:`django:topics-testing-primaryreplica`.
+   @pytest.mark.django_db(databases=['default', 'other'])
+   def test_spam():
+       assert MyModel.objects.using('other').count() == 0
 
-If you have any ideas about the best API to support multiple databases
-directly in ``pytest-django`` please get in touch, we are interested
-in eventually supporting this but unsure about simply following
-Django's approach.
+For details see :py:attr:`django.test.TransactionTestCase.databases` and
+:py:attr:`django.test.TestCase.databases`.
 
-See `pull request 431 <https://github.com/pytest-dev/pytest-django/pull/431>`_
-for an idea/discussion to approach this.
 
 ``--reuse-db`` - reuse the testing database between test runs
 --------------------------------------------------------------

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -24,7 +24,7 @@ Markers
 ``pytest.mark.django_db`` - request database access
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. py:function:: pytest.mark.django_db([transaction=False, reset_sequences=False])
+.. py:function:: pytest.mark.django_db([transaction=False, reset_sequences=False, databases=None])
 
   This is used to mark a test function as requiring the database. It
   will ensure the database is set up correctly for the test. Each test
@@ -53,6 +53,23 @@ Markers
     ``False``.  Must be used together with ``transaction=True`` to have an
     effect.  Please be aware that not all databases support this feature.
     For details see :py:attr:`django.test.TransactionTestCase.reset_sequences`.
+
+
+  :type databases: Union[Iterable[str], str, None]
+  :param databases:
+    .. caution::
+
+      This argument is **experimental** and is subject to change without
+      deprecation. We are still figuring out the best way to expose this
+      functionality. If you are using this successfully or unsuccessfully,
+      `let us know <https://github.com/pytest-dev/pytest-django/issues/924>`_!
+
+    The ``databases`` argument defines which databases in a multi-database
+    configuration will be set up and may be used by the test.  Defaults to
+    only the ``default`` database.  The special value ``"__all__"`` may be use
+    to specify all configured databases.
+    For details see :py:attr:`django.test.TransactionTestCase.databases` and
+    :py:attr:`django.test.TestCase.databases`.
 
 .. note::
 

--- a/pytest_django_test/app/migrations/0001_initial.py
+++ b/pytest_django_test/app/migrations/0001_initial.py
@@ -24,5 +24,20 @@ class Migration(migrations.Migration):
                 ),
                 ("name", models.CharField(max_length=100)),
             ],
-        )
+        ),
+        migrations.CreateModel(
+            name="SecondItem",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=100)),
+            ],
+        ),
     ]

--- a/pytest_django_test/app/models.py
+++ b/pytest_django_test/app/models.py
@@ -1,5 +1,11 @@
 from django.db import models
 
 
+# Routed to database "main".
 class Item(models.Model):
+    name = models.CharField(max_length=100)  # type: str
+
+
+# Routed to database "second".
+class SecondItem(models.Model):
     name = models.CharField(max_length=100)  # type: str

--- a/pytest_django_test/db_helpers.py
+++ b/pytest_django_test/db_helpers.py
@@ -26,6 +26,9 @@ else:
         # An explicit test db name was given, is that as the base name
         TEST_DB_NAME = "{}_inner".format(TEST_DB_NAME)
 
+SECOND_DB_NAME = DB_NAME + '_second' if DB_NAME is not None else None
+SECOND_TEST_DB_NAME = TEST_DB_NAME + '_second' if DB_NAME is not None else None
+
 
 def get_db_engine():
     return _settings["ENGINE"].split(".")[-1]

--- a/pytest_django_test/db_router.py
+++ b/pytest_django_test/db_router.py
@@ -1,0 +1,14 @@
+class DbRouter:
+    def db_for_read(self, model, **hints):
+        if model._meta.app_label == 'app' and model._meta.model_name == 'seconditem':
+            return 'second'
+        return None
+
+    def db_for_write(self, model, **hints):
+        if model._meta.app_label == 'app' and model._meta.model_name == 'seconditem':
+            return 'second'
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        if app_label == 'app' and model_name == 'seconditem':
+            return db == 'second'

--- a/pytest_django_test/settings_base.py
+++ b/pytest_django_test/settings_base.py
@@ -27,3 +27,5 @@ TEMPLATES = [
         "OPTIONS": {},
     }
 ]
+
+DATABASE_ROUTERS = ['pytest_django_test.db_router.DbRouter']

--- a/pytest_django_test/settings_mysql_innodb.py
+++ b/pytest_django_test/settings_mysql_innodb.py
@@ -6,7 +6,38 @@ from .settings_base import *  # noqa: F401 F403
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
-        "NAME": "pytest_django_should_never_get_accessed",
+        "NAME": "pytest_django_tests_default",
+        "USER": environ.get("TEST_DB_USER", "root"),
+        "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
+        "HOST": environ.get("TEST_DB_HOST", "localhost"),
+        "OPTIONS": {
+            "init_command": "SET default_storage_engine=InnoDB",
+            "charset": "utf8mb4",
+        },
+        "TEST": {
+            "CHARSET": "utf8mb4",
+            "COLLATION": "utf8mb4_unicode_ci",
+        },
+    },
+    "replica": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "pytest_django_tests_replica",
+        "USER": environ.get("TEST_DB_USER", "root"),
+        "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
+        "HOST": environ.get("TEST_DB_HOST", "localhost"),
+        "OPTIONS": {
+            "init_command": "SET default_storage_engine=InnoDB",
+            "charset": "utf8mb4",
+        },
+        "TEST": {
+            "MIRROR": "default",
+            "CHARSET": "utf8mb4",
+            "COLLATION": "utf8mb4_unicode_ci",
+        },
+    },
+    "second": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "pytest_django_tests_second",
         "USER": environ.get("TEST_DB_USER", "root"),
         "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
         "HOST": environ.get("TEST_DB_HOST", "localhost"),

--- a/pytest_django_test/settings_mysql_myisam.py
+++ b/pytest_django_test/settings_mysql_myisam.py
@@ -6,7 +6,38 @@ from .settings_base import *  # noqa: F401 F403
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
-        "NAME": "pytest_django_should_never_get_accessed",
+        "NAME": "pytest_django_tests_default",
+        "USER": environ.get("TEST_DB_USER", "root"),
+        "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
+        "HOST": environ.get("TEST_DB_HOST", "localhost"),
+        "OPTIONS": {
+            "init_command": "SET default_storage_engine=MyISAM",
+            "charset": "utf8mb4",
+        },
+        "TEST": {
+            "CHARSET": "utf8mb4",
+            "COLLATION": "utf8mb4_unicode_ci",
+        },
+    },
+    "replica": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "pytest_django_tests_replica",
+        "USER": environ.get("TEST_DB_USER", "root"),
+        "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
+        "HOST": environ.get("TEST_DB_HOST", "localhost"),
+        "OPTIONS": {
+            "init_command": "SET default_storage_engine=MyISAM",
+            "charset": "utf8mb4",
+        },
+        "TEST": {
+            "MIRROR": "default",
+            "CHARSET": "utf8mb4",
+            "COLLATION": "utf8mb4_unicode_ci",
+        },
+    },
+    "second": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "pytest_django_tests_second",
         "USER": environ.get("TEST_DB_USER", "root"),
         "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
         "HOST": environ.get("TEST_DB_HOST", "localhost"),

--- a/pytest_django_test/settings_postgres.py
+++ b/pytest_django_test/settings_postgres.py
@@ -14,7 +14,24 @@ except ImportError:
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "pytest_django_should_never_get_accessed",
+        "NAME": "pytest_django_tests_default",
+        "USER": environ.get("TEST_DB_USER", ""),
+        "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
+        "HOST": environ.get("TEST_DB_HOST", ""),
+    },
+    "replica": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "pytest_django_tests_replica",
+        "USER": environ.get("TEST_DB_USER", ""),
+        "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
+        "HOST": environ.get("TEST_DB_HOST", ""),
+        "TEST": {
+            "MIRROR": "default",
+        },
+    },
+    "second": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "pytest_django_tests_second",
         "USER": environ.get("TEST_DB_USER", ""),
         "PASSWORD": environ.get("TEST_DB_PASSWORD", ""),
         "HOST": environ.get("TEST_DB_HOST", ""),

--- a/pytest_django_test/settings_sqlite.py
+++ b/pytest_django_test/settings_sqlite.py
@@ -1,8 +1,20 @@
 from .settings_base import *  # noqa: F401 F403
 
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": "/should_not_be_accessed",
-    }
+    },
+    "replica": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "/should_not_be_accessed",
+        "TEST": {
+            "MIRROR": "default",
+        },
+    },
+    "second": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "/should_not_be_accessed",
+    },
 }

--- a/pytest_django_test/settings_sqlite_file.py
+++ b/pytest_django_test/settings_sqlite_file.py
@@ -6,12 +6,27 @@ from .settings_base import *  # noqa: F401 F403
 # tests (via setting TEST_NAME / TEST['NAME']).
 
 # The name as expected / used by Django/pytest_django (tests/db_helpers.py).
-_fd, _filename = tempfile.mkstemp(prefix="test_")
+_fd, _filename_default = tempfile.mkstemp(prefix="test_")
+_fd, _filename_replica = tempfile.mkstemp(prefix="test_")
+_fd, _filename_second = tempfile.mkstemp(prefix="test_")
 
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "/pytest_django_should_never_get_accessed",
-        "TEST": {"NAME": _filename},
-    }
+        "NAME": "/pytest_django_tests_default",
+        "TEST": {"NAME": _filename_default},
+    },
+    "replica": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "/pytest_django_tests_replica",
+        "TEST": {
+            "MIRROR": "default",
+            "NAME": _filename_replica,
+        },
+    },
+    "second": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "/pytest_django_tests_second",
+        "TEST": {"NAME": _filename_second},
+    },
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,9 @@ def testdir(testdir, monkeypatch):
 
 @pytest.fixture(scope="function")
 def django_testdir(request, testdir, monkeypatch):
-    from pytest_django_test.db_helpers import DB_NAME, TEST_DB_NAME
+    from pytest_django_test.db_helpers import (
+        DB_NAME, TEST_DB_NAME, SECOND_DB_NAME, SECOND_TEST_DB_NAME,
+    )
 
     marker = request.node.get_closest_marker("django_project")
 
@@ -51,6 +53,8 @@ def django_testdir(request, testdir, monkeypatch):
         db_settings = copy.deepcopy(settings.DATABASES)
         db_settings["default"]["NAME"] = DB_NAME
         db_settings["default"]["TEST"]["NAME"] = TEST_DB_NAME
+        db_settings["second"]["NAME"] = SECOND_DB_NAME
+        db_settings["second"].setdefault("TEST", {})["NAME"] = SECOND_TEST_DB_NAME
 
     test_settings = (
         dedent(
@@ -66,6 +70,7 @@ def django_testdir(request, testdir, monkeypatch):
             compat.register()
 
         DATABASES = %(db_settings)s
+        DATABASE_ROUTERS = ['pytest_django_test.db_router.DbRouter']
 
         INSTALLED_APPS = [
             'django.contrib.auth',

--- a/tests/test_db_setup.py
+++ b/tests/test_db_setup.py
@@ -519,6 +519,15 @@ class TestNativeMigrations:
                         },
                         bases=(models.Model,),
                     ),
+                    migrations.CreateModel(
+                        name='SecondItem',
+                        fields=[
+                            ('id', models.AutoField(serialize=False,
+                                                    auto_created=True,
+                                                    primary_key=True)),
+                            ('name', models.CharField(max_length=100)),
+                        ],
+                    ),
                     migrations.RunPython(
                         print_it,
                     ),


### PR DESCRIPTION
This PR adds experimental support for multi-database configurations - refs #924.

Currently, we only add a `databases` argument to the `django_db` marker, which corresponds to the `databases` attribute of Django's `TransactionTestCase`/`TestCase`. We probably also want some fixture to be able to control this more nicely for an entire file, module, session etc, but that can be done later.

Since I'm not really sure about the API, I marked it as experimental for now. If it works out fine, we can stabilize it.