### PR TITLE
Better Example for django_db_setup no-op

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -368,11 +368,7 @@ Put this into ``conftest.py``::
 
     @pytest.fixture(scope='session')
     def django_db_setup():
-        settings.DATABASES['default'] = {
-            'ENGINE': 'django.db.backends.mysql',
-            'HOST': 'db.example.com',
-            'NAME': 'external_db',
-        }
+        pass
 
 
 Populate the database with initial test data


### PR DESCRIPTION
Small improvement for [this section](https://pytest-django.readthedocs.io/en/latest/database.html#using-an-existing-external-database-for-tests) of the docs which removes extraneous code from the example and more clearly illustrates what is being directed