### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -386,7 +386,7 @@ Populate the test database if you don't use transactional or live_server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you are using the :func:`pytest.mark.django_db` marker or :fixture:`db`
-fixture, you probably don't want to explictly handle transactions in your
+fixture, you probably don't want to explicitly handle transactions in your
 tests. In this case, it is sufficient to populate your database only
 once. You can put code like this in ``conftest.py``::
 

--- a/docs/managing_python_path.rst
+++ b/docs/managing_python_path.rst
@@ -5,7 +5,7 @@ Managing the Python path
 
 pytest needs to be able to import the code in your project. Normally, when
 interacting with Django code, the interaction happens via ``manage.py``, which
-will implicilty add that directory to the Python path.
+will implicitly add that directory to the Python path.
 
 However, when Python is started via the ``pytest`` command, some extra care is
 needed to have the Python path setup properly. There are two ways to handle

--- a/tests/test_manage_py_scan.py
+++ b/tests/test_manage_py_scan.py
@@ -4,9 +4,9 @@ import pytest
 @pytest.mark.django_project(project_root="django_project_root", create_manage_py=True)
 def test_django_project_found(django_testdir) -> None:
     # XXX: Important: Do not chdir() to django_project_root since runpytest_subprocess
-    # will call "python /path/to/pytest.py", which will impliclity add cwd to
+    # will call "python /path/to/pytest.py", which will implicitly add cwd to
     # the path. By instead calling "python /path/to/pytest.py
-    # django_project_root", we avoid impliclity adding the project to sys.path
+    # django_project_root", we avoid implicitly adding the project to sys.path
     # This matches the behaviour when pytest is called directly as an
     # executable (cwd is not added to the Python path)
 


### PR DESCRIPTION
There are small typos in:
- docs/database.rst
- docs/managing_python_path.rst
- tests/test_manage_py_scan.py

Fixes:
- Should read `implicitly` rather than `impliclity`.
- Should read `implicitly` rather than `implicilty`.
- Should read `explicitly` rather than `explictly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md