### PR TITLE
assertTemplateUsed return type

### DIFF
--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -41,6 +41,7 @@ for assert_func in assertions_names:
 
 if TYPE_CHECKING:
     from django.http import HttpResponse
+    from django.test.testcases import _AssertTemplateUsedContext
 
     def assertRedirects(
         response: HttpResponse,
@@ -102,7 +103,7 @@ if TYPE_CHECKING:
         template_name: Optional[str] = ...,
         msg_prefix: str = ...,
         count: Optional[int] = ...,
-    ) -> None:
+    ) -> _AssertTemplateUsedContext:
         ...
 
     def assertTemplateNotUsed(

--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -41,7 +41,7 @@ for assert_func in assertions_names:
 
 if TYPE_CHECKING:
     from django.http import HttpResponse
-    from django.test.testcases import _AssertTemplateUsedContext
+    from django.test.testcases import _AssertTemplateNotUsedContext, _AssertTemplateUsedContext
 
     def assertRedirects(
         response: HttpResponse,
@@ -110,7 +110,7 @@ if TYPE_CHECKING:
         response: Optional[HttpResponse] = ...,
         template_name: Optional[str] = ...,
         msg_prefix: str = ...,
-    ) -> None:
+    ) -> _AssertTemplateNotUsedContext:
         ...
 
     def assertRaisesMessage(

--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -41,7 +41,6 @@ for assert_func in assertions_names:
 
 if TYPE_CHECKING:
     from django.http import HttpResponse
-    from django.test.testcases import _AssertTemplateNotUsedContext, _AssertTemplateUsedContext
 
     def assertRedirects(
         response: HttpResponse,
@@ -103,14 +102,14 @@ if TYPE_CHECKING:
         template_name: Optional[str] = ...,
         msg_prefix: str = ...,
         count: Optional[int] = ...,
-    ) -> _AssertTemplateUsedContext:
+    ):
         ...
 
     def assertTemplateNotUsed(
         response: Optional[HttpResponse] = ...,
         template_name: Optional[str] = ...,
         msg_prefix: str = ...,
-    ) -> _AssertTemplateNotUsedContext:
+    ):
         ...
 
     def assertRaisesMessage(


### PR DESCRIPTION
Hi! Thank you for this invaluable library.

I recently added a test to my project that looked something like this:

```python
def test_template(client: Client) -> None:
    with assertTemplateUsed("app/template.html"):
        client.get(URL)
```

This caused a typing error from MyPy:

```
"assertTemplateUsed" does not return a value  [func-returns-value]
```

This is because the [type hints added for this function in `pytest_django/asserts.py`](https://github.com/pytest-dev/pytest-django/blob/cf6b229bce0c717bc590d8fd7cef281f3aa2c1fa/pytest_django/asserts.py#L100-L113) incorrectly indicate a return type of `None`.

I hope this change will fix the error. While I was there, I noticed that the return type of `assertTemplateNotUsed` was similarly incorrect, so I've addressed that too.

I realise that I have imported an underscore-prefixed class here, and that might be a cause of some concern. I notice the class has existed for around 10 years, so I assume changes to the import are unlikely. That said please let me know if you would prefer me to replace the return type with a more generic `typing.ContextManager`, or if there is another approach that I might not have considered.

For reference, here is where Django returns instances of these classes:

https://github.com/django/django/blob/a7be74d01775f862d18add17b10296c8583e35d8/django/test/testcases.py#L653

https://github.com/django/django/blob/a7be74d01775f862d18add17b10296c8583e35d8/django/test/testcases.py#L682