### PR TITLE
Fix `LiveServer` for in-memory SQLite database on Django >= 3.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Rafal Stozek
 Donald Stufft <donald@stufft.io>
 Nicolas Delaby <ticosax@free.fr>
 Daniel Hahler <https://twitter.com/blueyed>
+Michael Howitz

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+unreleased
+----------
+
+Bugfixes
+^^^^^^^^
+
+* Fix fixture :fixture:`LiveServer` when using an in-memory SQLite database on
+  Django >= 3.
+
+
 v4.4.0 (2021-06-06)
 -------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,8 +7,8 @@ unreleased
 Bugfixes
 ^^^^^^^^
 
-* Fix fixture :fixture:`LiveServer` when using an in-memory SQLite database on
-  Django >= 3.
+* Fix fixture ``.live_server_helper.LiveServer`` when using an in-memory SQLite
+  database on Django >= 3.
 
 
 v4.4.0 (2021-06-06)

--- a/pytest_django/django_compat.py
+++ b/pytest_django/django_compat.py
@@ -1,6 +1,11 @@
 # Note that all functions here assume django is available.  So ensure
 # this is the case before you call them.
 
+import pkg_resources
+
+
+IS_DJANGO_2 = pkg_resources.get_distribution("Django").version < '3'
+
 
 def is_django_unittest(request_or_item) -> bool:
     """Returns True if the request_or_item is a Django test case, otherwise False"""

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -64,6 +64,7 @@ class LiveServer:
 
     def stop(self) -> None:
         """Stop the server"""
+        from django.db import connections
 
         liveserver_kwargs = {}  # type: Dict[str, Any]
 

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict
+
 from .django_compat import IS_DJANGO_2
 
 

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -24,7 +24,10 @@ class LiveServer:
                 and conn.settings_dict["NAME"] == ":memory:"
             ):
                 # Explicitly enable thread-shareability for this connection
-                conn.allow_thread_sharing = True
+                try:
+                    conn.inc_thread_sharing()
+                except AttributeError:  # Django < 3
+                    conn.allow_thread_sharing = True
                 connections_override[conn.alias] = conn
 
         liveserver_kwargs["connections_override"] = connections_override

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,3 +95,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-psycopg2cffi.*]
 ignore_missing_imports = True
+[mypy-pkg_resources.*]
+ignore_missing_imports = True


### PR DESCRIPTION
`allow_thread_sharing` is no longer writeable since Django 3.0a1.