### PR TITLE
Fix settings fixture leak by resetting mutated values

### DIFF
--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -555,7 +555,7 @@ class TestLiveServer:
     MY_LIST = [1]
     """
 )
-def test_setting_mutation_does_not_leak(django_testdir, settings):
+def test_setting_mutation_does_not_leak(django_testdir, settings) -> None:
     django_testdir.makepyfile(
         """
         def test_dict_initial_value(settings):
@@ -578,6 +578,15 @@ def test_setting_mutation_does_not_leak(django_testdir, settings):
     )
     result = django_testdir.runpytest_subprocess("-s")
     result.stdout.fnmatch_lines(["* 4 passed*"])
+
+
+def test_finalize_resets_mutated_value(settings) -> None:
+    original = settings.ALLOWED_HOSTS.copy()
+    settings.ALLOWED_HOSTS.append('foo')
+    settings.finalize()
+    assert settings._to_restore == []
+    assert settings._original_values == {}
+    assert original == settings.ALLOWED_HOSTS
 
 
 @pytest.mark.parametrize("username_field", ("email", "identifier"))


### PR DESCRIPTION
Mutated attributes (i.e. dictionaries, lists) on the `settings` fixture leak into subsequent tests. 

```python
# settings.py
MY_DICT = {'a': 1}

# test_settings.py
def test_setting(settings):
    assert settings.MY_DICT == {'a': 1}
    settings.MY_DICT['a'] = 2  # Mutate the dict


def test_setting_resets(settings):
    assert settings.MY_DICT == {'a': 1}  # Fails
```

Django's `override_settings` context manager re-assigns the setting and, the framework provides `modify_settings` to mutate dicts and lists without having to redefine them in their entirety. 

This PR adds a mechanism on `SettingsWrapper` which copies the original value of the setting on `__getattr__`. During the finalize step, an additional check is made to all attributes "checked out". If the present value no longer equals to the original, it is reset.