### PR TITLE
Add USE_TZ to test settings.

### DIFF
--- a/pytest_django_test/settings_base.py
+++ b/pytest_django_test/settings_base.py
@@ -30,4 +30,4 @@ TEMPLATES = [
 
 DATABASE_ROUTERS = ['pytest_django_test.db_router.DbRouter']
 
-USE_TZ = False
+USE_TZ = True

--- a/pytest_django_test/settings_base.py
+++ b/pytest_django_test/settings_base.py
@@ -29,3 +29,5 @@ TEMPLATES = [
 ]
 
 DATABASE_ROUTERS = ['pytest_django_test.db_router.DbRouter']
+
+USE_TZ = False


### PR DESCRIPTION
This patch will remove below warning for django main
```
RemovedInDjango50Warning: The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.
```