### PR TITLE
Drop Django 3.0 support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
           python: 3.9
           allow_failure: false
 
-        - name: py37-dj30-mysql_innodb-coverage
+        - name: py37-dj31-mysql_innodb-coverage
           python: 3.7
           allow_failure: false
 
@@ -77,10 +77,6 @@ jobs:
 
         - name: py37-dj22-sqlite-xdist-coverage
           python: 3.7
-          allow_failure: false
-
-        - name: py38-dj30-sqlite-xdist-coverage
-          python: 3.8
           allow_failure: false
 
         - name: py38-dj32-sqlite-xdist-coverage

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ pytest-django allows you to test your Django project/applications with the
   <https://pytest-django.readthedocs.io/en/latest/contributing.html>`_
 * Version compatibility:
 
-  * Django: 2.2, 3.0, 3.1, 3.2 and latest main branch (compatible at the time of
+  * Django: 2.2, 3.1, 3.2 and latest main branch (compatible at the time of
     each release)
   * Python: CPython>=3.5 or PyPy 3
   * pytest: >=5.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 2.2
-    Framework :: Django :: 3.0
     Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Intended Audience :: Developers

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
     py310-dj{main,32}-postgres
-    py39-dj{main,32,31,30,22}-postgres
-    py38-dj{main,32,31,30,22}-postgres
-    py37-dj{32,31,30,22}-postgres
-    py36-dj{32,31,30,22}-postgres
+    py39-dj{main,32,31,22}-postgres
+    py38-dj{main,32,31,22}-postgres
+    py37-dj{32,31,22}-postgres
+    py36-dj{32,31,22}-postgres
     py35-dj{22}-postgres
     checkqa
 
@@ -14,7 +14,6 @@ deps =
     djmain: https://github.com/django/django/archive/main.tar.gz
     dj32: Django>=3.2,<4.0
     dj31: Django>=3.1,<3.2
-    dj30: Django>=3.0,<3.1
     dj22: Django>=2.2,<2.3
 
     mysql_myisam: mysqlclient==1.4.2.post1


### PR DESCRIPTION
Since Django 3.0 doesn't receive an update, we can also drop it's support.
https://www.djangoproject.com/download/