### PR TITLE
Wire up cls.setUpTestData for class level fixtures

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -343,3 +343,21 @@ class Test_database_blocking:
                 'or the "db" or "transactional_db" fixtures to enable it.'
             ]
         )
+
+
+# TODO: If this is omitted, the error is confusing:
+#  AttributeError: 'TestDatabaseClassAutoCaching' object has no attribute 'item_1'
+@pytest.mark.django_db
+class TestDatabaseClassAutoCaching:
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.item_1 = Item.objects.create()
+
+    # But it's not idiomatic for pytest:
+    def test_foo_c(self):
+        self.item_1.name = 'foo'
+        self.item_1.save()
+
+    def test_bar_c(self):
+        assert not self.item_1.name


### PR DESCRIPTION
Reimplement the Django TestCase's setUpTestData. Since we are
already calling the setUpClass machinery from TestCase, it's a
simple step to arrange for PytestDjangoTestCase to call the real
test class's setUpTestData classmethod.

This allows us to defer to the existing Django lifecycle hook machinery,
and also use the Django 3.2 implementation for TestData which
uses a descriptor to handle re-loading model instances between tests.
(It does this by memoizing the pre-test instances, so this avoids
us having to add a DB transaction or refresh_from_db() to reset the
testData.)

Partially fixes #514