### PR TITLE
Fix `LiveServer` for in-memory SQLite database on Django >= 3.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Donald Stufft <donald@stufft.io>
 Nicolas Delaby <ticosax@free.fr>
 Daniel Hahler <https://twitter.com/blueyed>
 Hasan Ramezani <hasan.r67@gmail.com>
+Michael Howitz

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+unreleased
+----------
+
+Bugfixes
+^^^^^^^^
+
+* Fix :fixture:`live_server` when using an in-memory SQLite database on
+  Django >= 3.0.
+
+
 v4.4.0 (2021-06-06)
 -------------------
 

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -62,7 +62,6 @@ class LiveServer:
         """Stop the server"""
         # Terminate the live server's thread.
         self.thread.terminate()
-        self.thread.join()
         # Restore shared connections' non-shareability.
         for conn in self.thread.connections_override.values():
             conn.dec_thread_sharing()

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -50,13 +50,17 @@ class LiveServer:
         self._live_server_modified_settings = modify_settings(
             ALLOWED_HOSTS={"append": host}
         )
+        # `_live_server_modified_settings` is enabled and disabled by
+        # `_live_server_helper`.
 
         self.thread.daemon = True
         self.thread.start()
         self.thread.is_ready.wait()
 
         if self.thread.error:
-            raise self.thread.error
+            error = self.thread.error
+            self.stop()
+            raise error
 
     def stop(self) -> None:
         """Stop the server"""

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -24,7 +24,7 @@ class LiveServer:
                 and conn.settings_dict["NAME"] == ":memory:"
             ):
                 # Explicitly enable thread-shareability for this connection
-                conn.allow_thread_sharing = True
+                conn.inc_thread_sharing()
                 connections_override[conn.alias] = conn
 
         liveserver_kwargs["connections_override"] = connections_override
@@ -60,8 +60,12 @@ class LiveServer:
 
     def stop(self) -> None:
         """Stop the server"""
+        # Terminate the live server's thread.
         self.thread.terminate()
         self.thread.join()
+        # Restore shared connections' non-shareability.
+        for conn in self.thread.connections_override.values():
+            conn.dec_thread_sharing()
 
     @property
     def url(self) -> str:

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -19,11 +19,8 @@ class LiveServer:
         for conn in connections.all():
             # If using in-memory sqlite databases, pass the connections to
             # the server thread.
-            if (
-                conn.settings_dict["ENGINE"] == "django.db.backends.sqlite3"
-                and conn.settings_dict["NAME"] == ":memory:"
-            ):
-                # Explicitly enable thread-shareability for this connection
+            if conn.vendor == 'sqlite' and conn.is_in_memory_db():
+                # Explicitly enable thread-shareability for this connection.
                 conn.inc_thread_sharing()
                 connections_override[conn.alias] = conn
 

--- a/pytest_django_test/db_helpers.py
+++ b/pytest_django_test/db_helpers.py
@@ -15,6 +15,8 @@ TEST_DB_NAME = _settings["TEST"]["NAME"]
 
 if _settings["ENGINE"] == "django.db.backends.sqlite3" and TEST_DB_NAME is None:
     TEST_DB_NAME = ":memory:"
+    SECOND_DB_NAME = ":memory:"
+    SECOND_TEST_DB_NAME = ":memory:"
 else:
     DB_NAME += "_inner"
 
@@ -25,8 +27,8 @@ else:
         # An explicit test db name was given, is that as the base name
         TEST_DB_NAME = "{}_inner".format(TEST_DB_NAME)
 
-SECOND_DB_NAME = DB_NAME + '_second' if DB_NAME is not None else None
-SECOND_TEST_DB_NAME = TEST_DB_NAME + '_second' if DB_NAME is not None else None
+    SECOND_DB_NAME = DB_NAME + '_second' if DB_NAME is not None else None
+    SECOND_TEST_DB_NAME = TEST_DB_NAME + '_second' if DB_NAME is not None else None
 
 
 def get_db_engine():

--- a/pytest_django_test/settings_sqlite.py
+++ b/pytest_django_test/settings_sqlite.py
@@ -4,17 +4,17 @@ from .settings_base import *  # noqa: F401 F403
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "/should_not_be_accessed",
+        "NAME": ":memory:",
     },
     "replica": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "/should_not_be_accessed",
+        "NAME": ":memory:",
         "TEST": {
             "MIRROR": "default",
         },
     },
     "second": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "/should_not_be_accessed",
+        "NAME": ":memory:",
     },
 }

--- a/pytest_django_test/settings_sqlite_file.py
+++ b/pytest_django_test/settings_sqlite_file.py
@@ -15,7 +15,9 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": "/pytest_django_tests_default",
-        "TEST": {"NAME": _filename_default},
+        "TEST": {
+            "NAME": _filename_default,
+        },
     },
     "replica": {
         "ENGINE": "django.db.backends.sqlite3",
@@ -28,6 +30,8 @@ DATABASES = {
     "second": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": "/pytest_django_tests_second",
-        "TEST": {"NAME": _filename_second},
+        "TEST": {
+            "NAME": _filename_second,
+        },
     },
 }


### PR DESCRIPTION
Updates #947 and adds a couple more commits.