### PR TITLE
correct pytest.ini spelling

### DIFF
--- a/docs/configuring_django.rst
+++ b/docs/configuring_django.rst
@@ -36,7 +36,7 @@ Example::
 Example contents of pytest.ini::
 
     [pytest]
-    DJANGO_SETTINGS_MODULE = test.settings
+    DJANGO_SETTINGS_MODULE=test.settings
 
 Order of choosing settings
 --------------------------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -52,7 +52,7 @@ contains:
 .. code-block:: ini
 
     [pytest]
-    DJANGO_SETTINGS_MODULE = yourproject.settings
+    DJANGO_SETTINGS_MODULE=yourproject.settings
 
 You can also specify your Django settings by setting the
 ``DJANGO_SETTINGS_MODULE`` environment variable or specifying the


### PR DESCRIPTION
No whitespaces allowed around `=`