### PR TITLE
docs: configuration for the src layout

### DIFF
--- a/docs/managing_python_path.rst
+++ b/docs/managing_python_path.rst
@@ -80,4 +80,33 @@ Using pytest-pythonpath
 
 You can also use the `pytest-pythonpath
 <https://pypi.python.org/pypi/pytest-pythonpath>`_ plugin to explicitly add paths to
-the Python path.
+the Python path. This will be natively supported in pytest 7 via the ``pythonpath``
+option.
+
+Example: project with src layout
+````````````````````````````````
+
+For a Django package using the ``src`` layout, with test settings located in a 
+``tests`` package at the top level::
+
+    myproj
+    ├── src
+    │   └── myproj
+    │       ├── __init__.py
+    │       └── main.py
+    └── tests
+        ├── testapp
+        |   ├── __init__.py
+        |   └── apps.py
+        ├── __init__.py
+        ├── settings.py
+        └── test_main.py
+
+You'll need to specify both the top level directory and ``src` for things to work::
+
+    [pytest]
+    DJANGO_SETTINGS_MODULE = tests.settings
+    pythonpaths = . src  # replace by pythonpath with pytest 7
+
+If you don't specify ``.``, the settings module won't be found and
+you'll get an import error: ``ImportError: No module named 'tests'``.

--- a/docs/managing_python_path.rst
+++ b/docs/managing_python_path.rst
@@ -75,13 +75,13 @@ add this directly to your project's requirements.txt file like this::
     pytest-django
 
 
-Using pytest-pythonpath
-~~~~~~~~~~~~~~~~~~~~~~~
+Using pytest's ``pythonpath`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can also use the `pytest-pythonpath
-<https://pypi.python.org/pypi/pytest-pythonpath>`_ plugin to explicitly add paths to
-the Python path. This will be natively supported in pytest 7 via the ``pythonpath``
-option.
+You can explicitly add paths to the Python search path using pytest's
+:pytest-confval:`pythonpath` option.
+This option is available since pytest 7; for older versions you can use the
+`pytest-pythonpath <https://pypi.python.org/pypi/pytest-pythonpath>`_ plugin.
 
 Example: project with src layout
 ````````````````````````````````
@@ -90,6 +90,7 @@ For a Django package using the ``src`` layout, with test settings located in a
 ``tests`` package at the top level::
 
     myproj
+    ├── pytest.ini
     ├── src
     │   └── myproj
     │       ├── __init__.py
@@ -106,7 +107,7 @@ You'll need to specify both the top level directory and ``src`` for things to wo
 
     [pytest]
     DJANGO_SETTINGS_MODULE = tests.settings
-    pythonpaths = . src  # replace by pythonpath with pytest 7
+    pythonpath = . src
 
 If you don't specify ``.``, the settings module won't be found and
 you'll get an import error: ``ImportError: No module named 'tests'``.

--- a/docs/managing_python_path.rst
+++ b/docs/managing_python_path.rst
@@ -102,7 +102,7 @@ For a Django package using the ``src`` layout, with test settings located in a
         ├── settings.py
         └── test_main.py
 
-You'll need to specify both the top level directory and ``src` for things to work::
+You'll need to specify both the top level directory and ``src`` for things to work::
 
     [pytest]
     DJANGO_SETTINGS_MODULE = tests.settings


### PR DESCRIPTION
Expand the documentation to explain how to configure the pythonpath for projects using the src layout.

Fix #738