### PR TITLE
tests: Sync expected stream for Pytest' version

### DIFF
--- a/tests/test_manage_py_scan.py
+++ b/tests/test_manage_py_scan.py
@@ -118,7 +118,12 @@ def test_django_project_found_invalid_settings_version(django_testdir, monkeypat
 
     result = django_testdir.runpytest_subprocess("django_project_root", "--version", "--version")
     assert result.ret == 0
-    result.stderr.fnmatch_lines(["*This is pytest version*"])
+    if hasattr(pytest, "version_tuple") and pytest.version_tuple >= (7, 0):
+        version_out = result.stdout
+    else:
+        version_out = result.stderr
+
+    version_out.fnmatch_lines(["*This is pytest version*"])
 
     result = django_testdir.runpytest_subprocess("django_project_root", "--help")
     assert result.ret == 0


### PR DESCRIPTION
https://docs.pytest.org/en/7.0.x/changelog.html#breaking-changes:
> [pytest#8246](https://github.com/pytest-dev/pytest/issues/8246): --version now writes version information to stdout rather than stderr.

Fixes: https://github.com/pytest-dev/pytest-django/issues/995