### PR TITLE
Fix byte and string comparison

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -119,7 +119,7 @@ dynamically in a hook or fixture.
 
      @pytest.mark.urls('myapp.test_urls')
      def test_something(client):
-         assert 'Success!' in client.get('/some_url_defined_in_test_urls/').content
+         assert b'Success!' in client.get('/some_url_defined_in_test_urls/').content
 
 
 ``pytest.mark.ignore_template_errors`` - ignore invalid template variables


### PR DESCRIPTION
`response.content` is a `bytes` object and doing a string comparison throws an error