### PR TITLE
Feature/verbose liveserver

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+vunreleased ()
+--------------
+
+Improvements
+^^^^^^^^^^^^
+
+* ``--liveserver-verbose`` command-line parameter, which allows to see
+  logs from live_server on the standard output, including tracebacks.
+  Useful for debugging.
+
 v4.5.2 (2021-12-07)
 -------------------
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -374,6 +374,10 @@ created in data migrations, you should add the
 You can also use ``--liveserver-verbose`` command-line argument, to outputs
 the liveserver logs to the standard output, including tracebacks. This is
 useful for debugging live server behaviour and environment-related problems.
+Take note, logs will be written to standard output, which is being supressed
+by pytest by default, so you will need to use ``-s`` or ``--capture=no``
+parameter too.
+
 
 .. note:: Combining database access fixtures.
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -371,6 +371,10 @@ depends on the ``transactional_db`` fixture. If tests depend on data
 created in data migrations, you should add the
 ``django_db_serialized_rollback`` fixture.
 
+You can also use ``--liveserver-verbose`` command-line argument, to outputs
+the liveserver logs to the standard output, including tracebacks. This is
+useful for debugging live server behaviour and environment-related problems.
+
 .. note:: Combining database access fixtures.
 
   When using multiple database fixtures together, only one of them is

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -378,6 +378,9 @@ Take note, logs will be written to standard output, which is being supressed
 by pytest by default, so you will need to use ``-s`` or ``--capture=no``
 parameter too.
 
+And if your live server still keeps acting weird, there is a switch called
+``--liveserver-debug`` which drops into debugger in the console
+whenever traceback occurs in a live server page.
 
 .. note:: Combining database access fixtures.
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -536,7 +536,11 @@ def live_server(request):
         "DJANGO_LIVE_TEST_SERVER_ADDRESS"
     ) or "localhost"
 
-    server = live_server_helper.LiveServer(addr)
+    live_server_class = live_server_helper.LiveServer
+    if request.config.getvalue("liveserver_verbose") is True:
+        live_server_class = live_server_helper.VerboseLiveServer
+
+    server = live_server_class(addr)
     request.addfinalizer(server.stop)
     return server
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -540,6 +540,9 @@ def live_server(request):
     if request.config.getvalue("liveserver_verbose") is True:
         live_server_class = live_server_helper.VerboseLiveServer
 
+        if request.config.getvalue("liveserver_debug") is True:
+            live_server_class = live_server_helper.VerboseDebuggingLiveServer
+
     server = live_server_class(addr)
     request.addfinalizer(server.stop)
     return server

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -8,9 +8,12 @@ class LiveServer:
     The ``live_server`` fixture handles creation and stopping.
     """
 
+    def get_live_server_thread_class(self):
+        from django.test.testcases import LiveServerThread
+        return LiveServerThread
+
     def __init__(self, addr: str) -> None:
         from django.db import connections
-        from django.test.testcases import LiveServerThread
         from django.test.utils import modify_settings
 
         liveserver_kwargs = {}  # type: Dict[str, Any]
@@ -42,7 +45,9 @@ class LiveServer:
             host = addr
         else:
             liveserver_kwargs["port"] = int(port)
-        self.thread = LiveServerThread(host, **liveserver_kwargs)
+
+        live_server_thread_class = self.get_live_server_thread_class()
+        self.thread = live_server_thread_class(host, **liveserver_kwargs)
 
         self._live_server_modified_settings = modify_settings(
             ALLOWED_HOSTS={"append": host}
@@ -79,3 +84,9 @@ class LiveServer:
 
     def __repr__(self) -> str:
         return "<LiveServer listening at %s>" % self.url
+
+
+class VerboseLiveServer(LiveServer):
+    def get_live_server_thread_class(self):
+        from .verbose_live_server import VerboseLiveServerThread
+        return VerboseLiveServerThread

--- a/pytest_django/live_server_helper.py
+++ b/pytest_django/live_server_helper.py
@@ -90,3 +90,9 @@ class VerboseLiveServer(LiveServer):
     def get_live_server_thread_class(self):
         from .verbose_live_server import VerboseLiveServerThread
         return VerboseLiveServerThread
+
+
+class VerboseDebuggingLiveServer(LiveServer):
+    def get_live_server_thread_class(self):
+        from .verbose_live_server import VerboseDebuggingLiveServerThread
+        return VerboseDebuggingLiveServerThread

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -124,6 +124,14 @@ def pytest_addoption(parser) -> None:
     parser.addini(
         SETTINGS_MODULE_ENV, "Django settings module to use by pytest-django."
     )
+    group.addoption(
+        "--liveserver-verbose",
+        "--liveserver_verbose",
+        action="store_true",
+        dest="liveserver_verbose",
+        default=False,
+        help="Enable verbose logging for live_server fixture",
+    )
 
     parser.addini(
         "django_find_project",

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -132,6 +132,15 @@ def pytest_addoption(parser) -> None:
         default=False,
         help="Enable verbose logging for live_server fixture",
     )
+    group.addoption(
+        "--liveserver-debug",
+        "--liveserver_debug",
+        action="store_true",
+        dest="liveserver_debug",
+        default=False,
+        help="Drops into debugger on tracebacks in live_server "
+             "(only if used with --liveserver-verbose)"
+    )
 
     parser.addini(
         "django_find_project",

--- a/pytest_django/verbose_live_server.py
+++ b/pytest_django/verbose_live_server.py
@@ -1,0 +1,21 @@
+import sys
+import traceback
+
+from django.core.servers.basehttp import ThreadedWSGIServer, WSGIRequestHandler
+from django.test.testcases import LiveServerThread
+
+
+class VerboseWSGIRequestHandler(WSGIRequestHandler):
+    def handle_uncaught_exception(self, request, resolver, exc_info):
+        traceback.print_tb(exc_info[2], file=sys.stderr)
+        return super(VerboseWSGIRequestHandler, self).handle_uncaught_exception(
+            request, resolver, exc_info)
+
+
+class VerboseLiveServerThread(LiveServerThread):
+    def _create_server(self):
+        return ThreadedWSGIServer(
+            (self.host, self.port),
+            VerboseWSGIRequestHandler,
+            allow_reuse_address=False
+        )

--- a/pytest_django/verbose_live_server.py
+++ b/pytest_django/verbose_live_server.py
@@ -6,16 +6,32 @@ from django.test.testcases import LiveServerThread
 
 
 class VerboseWSGIRequestHandler(WSGIRequestHandler):
+    debug_on_traceback = False
+
     def handle_uncaught_exception(self, request, resolver, exc_info):
         traceback.print_tb(exc_info[2], file=sys.stderr)
+        if self.debug_on_traceback:
+            import pytest
+            pytest.set_trace()
+
         return super(VerboseWSGIRequestHandler, self).handle_uncaught_exception(
             request, resolver, exc_info)
 
 
+class VerboseDebuggingWSGIRequestHandler(VerboseWSGIRequestHandler):
+    debug_on_traceback = True
+
+
 class VerboseLiveServerThread(LiveServerThread):
+    request_handler_class = VerboseWSGIRequestHandler
+
     def _create_server(self):
         return ThreadedWSGIServer(
             (self.host, self.port),
-            VerboseWSGIRequestHandler,
+            self.request_handler_class,
             allow_reuse_address=False
         )
+
+
+class VerboseDebuggingLiveServerThread(VerboseLiveServerThread):
+    request_handler_class = VerboseDebuggingWSGIRequestHandler


### PR DESCRIPTION
Basing on my usage and on StackOverflow questions, the world needs ``--liveserver-verbose`` command line argument, which this branch implements. 

Default live server is quiet. Django guys made it quiet. And, well, for some, maybe this is good. Because theory says that you're supposed to have a lot of unit tests and when you start integration testing all your code should be A1-OKAY and 100% tested... in an ideal world. 

... but in this world, I tend to stumble on "500 ERROR" spewed by LiveServer at my code. Unable to debug, unable to print stuff to the console. Helpless, really. Especially helpless, when I know that everything in the code is okay and the error is because of environment problems. But still, unable to debug it, I feel helpless. 

And I don't like the feeling of being helpless. 

So I present to you the ``--liveserver-verbose`` argument. 

It prints stuff on the stdout!

It can even print out a backtrace. 

Is it ugly? Yes. 

Can it be improved? Yes! Just like pytest-durations, it would be lovely to have some frames and a nicely formatted output. 

But... I almost pressed "CREATE PULL REQUEST" here... I can improve it already. 

Another option I present to you is ``liveserver-debug``. This option drops to debugger in the console when a traceback occurs. 

Am I cool now? Am I the good guy? Can I take constructive criticism? Was I able to do all of that without switches on the command line? LET'S SEE!

What I would really like to see with this branch is how to collect those stdout texts nicely. If I don't use ``-s`` switch it prints out stderr on failing tests nicely. Perhaps you can help me improve this. Thanks!