### PR TITLE
fix: don't crash if mail.outbox doesn't exist

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -502,7 +502,8 @@ def _dj_autoclear_mailbox() -> None:
 
     from django.core import mail
 
-    del mail.outbox[:]
+    if hasattr(mail, "outbox"):
+        del mail.outbox[:]
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-django/issues/993