### PR TITLE
Fix assert function signatures that expect HTTP response

### DIFF
--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -40,10 +40,10 @@ for assert_func in assertions_names:
 
 
 if TYPE_CHECKING:
-    from django.http import HttpResponse
+    from django.http.response import HttpResponseBase
 
     def assertRedirects(
-        response: HttpResponse,
+        response: HttpResponseBase,
         expected_url: str,
         status_code: int = ...,
         target_status_code: int = ...,
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
         ...
 
     def assertContains(
-        response: HttpResponse,
+        response: HttpResponseBase,
         text: object,
         count: Optional[int] = ...,
         status_code: int = ...,
@@ -70,7 +70,7 @@ if TYPE_CHECKING:
         ...
 
     def assertNotContains(
-        response: HttpResponse,
+        response: HttpResponseBase,
         text: object,
         status_code: int = ...,
         msg_prefix: str = ...,
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
         ...
 
     def assertFormError(
-        response: HttpResponse,
+        response: HttpResponseBase,
         form: str,
         field: Optional[str],
         errors: Union[str, Sequence[str]],
@@ -88,7 +88,7 @@ if TYPE_CHECKING:
         ...
 
     def assertFormsetError(
-        response: HttpResponse,
+        response: HttpResponseBase,
         formset: str,
         form_index: Optional[int],
         field: Optional[str],
@@ -98,7 +98,7 @@ if TYPE_CHECKING:
         ...
 
     def assertTemplateUsed(
-        response: Optional[HttpResponse] = ...,
+        response: Optional[Union[HttpResponseBase, str]] = ...,
         template_name: Optional[str] = ...,
         msg_prefix: str = ...,
         count: Optional[int] = ...,
@@ -106,7 +106,7 @@ if TYPE_CHECKING:
         ...
 
     def assertTemplateNotUsed(
-        response: Optional[HttpResponse] = ...,
+        response: Optional[Union[HttpResponseBase, str]] = ...,
         template_name: Optional[str] = ...,
         msg_prefix: str = ...,
     ):


### PR DESCRIPTION
Updating to the latest version(s) of `django-stubs` from `1.10.1` reveals errors such as:

> Argument 1 to "assertContains" has incompatible type "_MonkeyPatchedWSGIResponse"; expected "HttpResponse"  [arg-type]

`django-stubs` expects a `HttpResponseBase` instead of `HttpResponse` (see: https://github.com/typeddjango/django-stubs/blob/0381fdb0227f0db96a584d8e916ae6d8b3d025a3/django-stubs/test/testcases.pyi#L102)

This PR changes the signatures to be in line with what `django-stubs` defines.