### PR TITLE
Add `pattern` argument to django_assert_num_queries fixture

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -412,6 +412,7 @@ Example
   :param num: expected number of queries
   :param connection: optional non-default DB connection
   :param str info: optional info message to display on failure
+  :param str pattern: optional regex pattern to filter queries to take into account
 
 This fixture allows to check for an expected number of DB queries.
 
@@ -431,6 +432,13 @@ Example usage::
 
         assert 'foo' in captured.captured_queries[0]['sql']
 
+Example counting only ``INSERT`` queries::
+
+    def test_queries(django_assert_num_queries):
+        with django_assert_num_queries(1, pattern=r'^INSERT\s') as captured:
+            Item.objects.create('foo')
+            Item.objects.filter(name='foo').update(name='bar')
+
 
 .. fixture:: django_assert_max_num_queries
 
@@ -442,6 +450,7 @@ Example usage::
   :param num: expected maximum number of queries
   :param connection: optional non-default DB connection
   :param str info: optional info message to display on failure
+  :param str pattern: optional regex pattern to filter queries to take into account
 
 This fixture allows to check for an expected maximum number of DB queries.
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -231,6 +231,13 @@ def test_django_assert_num_queries_output_info(django_testdir) -> None:
 
 
 @pytest.mark.django_db
+def test_django_assert_num_queries_pattern(django_assert_num_queries) -> None:
+    with django_assert_num_queries(1, pattern=r'^INSERT\s'):
+        Item.objects.create(name="foo")
+        Item.objects.filter(name="foo").update(name="bar")
+
+
+@pytest.mark.django_db
 def test_django_capture_on_commit_callbacks(django_capture_on_commit_callbacks) -> None:
     if not connection.features.supports_transactions:
         pytest.skip("transactions required for this test")


### PR DESCRIPTION
This optional argument allows to filter the queries to take into account for the assertion.

It may be useful to check for the count of only certain queries. For example, a use case of mine is to skip SAVEPOINT queries by using:
```
NO_SAVEPOINT_PATTERN=r'(?!^(ROLLBACK TO |RELEASE )?SAVEPOINT [`"].+[`"]$)'
...
with django_assert_num_queries(n, pattern=NO_SAVEPOINT_PATTERN):
   ...
```