### PR TITLE
WIP: Add Django 4.2 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,11 +69,11 @@ jobs:
           python: '3.10'
           allow_failure: false
 
-        - name: py311-dj41-postgres-xdist-coverage
+        - name: py311-dj42-postgres-xdist-coverage
           python: '3.11'
           allow_failure: false
 
-        - name: py310-dj40-postgres-xdist-coverage
+        - name: py310-dj41-postgres-xdist-coverage
           python: '3.10'
           allow_failure: false
 
@@ -85,7 +85,7 @@ jobs:
           python: '3.11'
           allow_failure: false
 
-        - name: py310-dj40-mysql_innodb-coverage
+        - name: py310-dj42-mysql_innodb-coverage
           python: '3.10'
           allow_failure: false
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ pytest-django allows you to test your Django project/applications with the
   <https://pytest-django.readthedocs.io/en/latest/contributing.html>`_
 * Version compatibility:
 
-  * Django: 3.2, 4.0, 4.1 and latest main branch (compatible at the time of
+  * Django: 3.2, 4.0, 4.1, 4.2 and latest main branch (compatible at the time of
     each release)
   * Python: CPython>=3.7 or PyPy 3
   * pytest: >=5.4

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Pending
 Improvements
 ^^^^^^^^^^^^
 
-* Official Django 4.1 support.
+* Official Django 4.1 & 4.2 support.
 
 * Official Python 3.11 support.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
-    py310-dj{main,41,40,32}-postgres
-    py39-dj{main,41,40,32}-postgres
-    py38-dj{main,41,40,32}-postgres
+    py311-dj{main,42,41}-postgres
+    py310-dj{main,42,41,40,32}-postgres
+    py39-dj{main,42,41,40,32}-postgres
+    py38-dj{main,42,41,40,32}-postgres
     py37-dj{32}-postgres
     linting
 
@@ -10,6 +11,7 @@ envlist =
 extras = testing
 deps =
     djmain: https://github.com/django/django/archive/main.tar.gz
+    dj42: Django>=4.2a1,<4.3
     dj41: Django>=4.1,<4.2
     dj40: Django>=4.0,<4.1
     dj32: Django>=3.2,<4.0


### PR DESCRIPTION
TODO:
- Currently blocked on https://github.com/jazzband/django-configurations/pull/349.
- I also want to add some testing for the new psycopg3 backend (with/without server-side bindings).