### PR TITLE
Fix verbose configuration option value check

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -600,7 +600,7 @@ def _assert_num_queries(
                 sqls = (q["sql"] for q in context.captured_queries)
                 msg += "\n\nQueries:\n========\n\n" + "\n\n".join(sqls)
             else:
-                msg += " (add -v option to show queries)"
+                msg += " (add -vv option to show queries)"
             pytest.fail(msg)
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -102,7 +102,7 @@ def test_django_assert_num_queries_db(request, django_assert_num_queries) -> Non
                 Item.objects.create(name="quux")
         assert excinfo.value.args == (
             "Expected to perform 2 queries but 1 was done "
-            "(add -v option to show queries)",
+            "(add -vv option to show queries)",
         )
         assert len(captured.captured_queries) == 1
 
@@ -122,7 +122,7 @@ def test_django_assert_max_num_queries_db(request, django_assert_max_num_queries
 
         assert excinfo.value.args == (
             "Expected to perform 2 queries or less but 3 were done "
-            "(add -v option to show queries)",
+            "(add -vv option to show queries)",
         )
         assert len(captured.captured_queries) == 3
         assert "1-foo" in captured.captured_queries[0]["sql"]


### PR DESCRIPTION
This commit corrects the check for the 'verbose' configuration option value. Previously, it was checked if the value was strictly greater than 0, but the use of '-v' flag sets the value to 0.

**Edit**: My original patch changed to `verbose = config.getoption("verbose") >= 0` in `fixtures.py`.