### PR TITLE
Add a `nested()` method to the SettingsWrapper class

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -401,6 +401,15 @@ Example
         settings.USE_TZ = True
         assert settings.USE_TZ
 
+Setting modifications within tests can be nested with the ``nested()`` context manager:
+
+::
+
+    def test_with_nested_settings(settings):
+        settings.USE_TZ = False
+        with settings.nested():
+            settings.USE_TZ = True
+        assert not settings.USE_TZ
 
 .. fixture:: django_assert_num_queries
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -1,4 +1,5 @@
 """All pytest-django fixtures"""
+import contextlib
 import os
 from contextlib import contextmanager
 from functools import partial
@@ -496,6 +497,16 @@ class SettingsWrapper:
             override.disable()
 
         del self._to_restore[:]
+
+    @contextlib.contextmanager
+    def nested(self):
+        to_restore = self.__class__._to_restore
+        self.__class__._to_restore = []
+        try:
+            yield
+        finally:
+            self.finalize()
+            self.__class__._to_restore = to_restore
 
 
 @pytest.fixture()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -327,6 +327,18 @@ class TestSettings:
         assert hasattr(settings, "SECRET_KEY")
         assert hasattr(real_settings, "SECRET_KEY")
 
+    def test_nested_settings(self, settings) -> None:
+        settings.SPAM = "SPAM"
+        with settings.nested():
+            settings.SPAM = "HAM"
+            with settings.nested():
+                settings.SPAM = "EGGS"
+                settings.FOO = "foobar"
+            assert settings.SPAM == "HAM"
+            assert not hasattr(settings, "FOO")
+
+        assert settings.SPAM == "SPAM"
+
     def test_signals(self, settings) -> None:
         result = []
 


### PR DESCRIPTION
The `override_settings` method works well in tests where you have the settings and the values you want to set upfront. But there are specific cases where this might not be true and where you want to ensure all settings modifications are rolled back after the block is complete. A contrived example:

```python
def test_something(settings):
    with object_creator() as creator:
        settings.FOO = creator.do_something_with_side_effects()
        do_something(settings.FOO) # Valid
    do_something(settings.FOO) # the object here is invalid as it's outside the context manager, but the setting is still there
```

You could use override settings for this, but it's a bit verbose and requires lots of nesting:

```python
def test_something(settings):
    with object_creator() as creator:
        with override_settings(FOO=creator.do_something_with_side_effects()):
            do_something(settings.FOO) # Valid
    settings.FOO # is no longer set
```

This PR adds a `nested()` method to the settings object that allows a bit of a more fluid interface for scoping modifications to settings and having them rolled back with a context manager:

```python
def test_something(settings):
    with settings.nested(), object_creator() as creator:
        settings.FOO = creator.do_something_with_side_effects()  
        do_something(settings.FOO) # valid
    settings.FOO # is no longer set
```

And this can be used by the custom `object_creator()` context manager itself if appropriate:

```python
def test_something(settings):
    with object_creator(settings) as creator:
        settings.FOO = creator.do_something_with_side_effects()
        do_something(settings.FOO) # Valid
    settings.FOO # is no longer set
```