### PR TITLE
Add a django_set_urlconf fixture

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -542,7 +542,7 @@ Example
     from django import http, urls
 
     def test_can_override_a_root_urlconf(django_set_urlconf):
-        def my_view(request: http.request.HttpRequest) -> http.response.HttpResponse:
+        def my_view(request):
             raise http.Http404()
 
         my_urlpatterns = (urls.path("test/view", my_view, name="test_view"),)

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -545,8 +545,9 @@ Example
         def my_view(request):
             raise http.Http404()
 
-        my_urlpatterns = (urls.path("test/view", my_view, name="test_view"),)
-        django_set_urlconf(my_urlpatterns)
+        django_set_urlconf([
+            urls.path("test/view", my_view, name="test_view")
+        ])
         assert urls.reverse("test_view") == "/test/view"
 
 Automatic cleanup

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -108,7 +108,8 @@ dynamically in a hook or fixture.
 
 .. py:function:: pytest.mark.urls(urls)
 
-   Specify a different ``settings.ROOT_URLCONF`` module for the marked tests.
+   Specify a different ``settings.ROOT_URLCONF`` module for the marked tests. Use
+   the :fixture:`django_set_urlconf` fixture to specify a different value inside tests.
 
    :type urls: str
    :param urls:
@@ -529,10 +530,13 @@ the ``django_mail_dnsname`` fixture, which defaults to
 "fake-tests.example.com".
 
 
+.. fixture:: django_set_urlconf
+
 ``django_set_urlconf``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-This fixture allows setting the ``settings.ROOT_URLCONF`` to a value created within the test.
+Call this fixture to set ``settings.ROOT_URLCONF`` to a list of urlpatterns created within the test.
+This keeps the URLs local unlike :func:`pytest.mark.urls`.
 
 Example
 """""""

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -529,6 +529,26 @@ the ``django_mail_dnsname`` fixture, which defaults to
 "fake-tests.example.com".
 
 
+``django_set_urlconf``
+~~~~~~~~~~~~~~~~~~~~~~
+
+This fixture allows setting the ``settings.ROOT_URLCONF`` to a value created within the test.
+
+Example
+"""""""
+
+::
+
+    from django import http, urls
+
+    def test_can_override_a_root_urlconf(django_set_urlconf):
+        def my_view(request: http.request.HttpRequest) -> http.response.HttpResponse:
+            raise http.Http404()
+
+        my_urlpatterns = (urls.path("test/view", my_view, name="test_view"),)
+        django_set_urlconf(my_urlpatterns)
+        assert urls.reverse("test_view") == "/test/view"
+
 Automatic cleanup
 -----------------
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -10,6 +10,7 @@ from urllib.error import HTTPError
 from urllib.request import urlopen
 
 import pytest
+from django import http, urls
 from django.conf import settings as real_settings
 from django.core import mail
 from django.db import connection, transaction
@@ -787,3 +788,12 @@ def test_mail_message_dns_patching_can_be_skipped(django_testdir) -> None:
         ["*test_mailbox_inner*", "django_mail_dnsname_mark", "PASSED*"]
     )
     assert result.ret == 0
+
+
+def test_django_set_urlconf(django_set_urlconf, client) -> None:
+    def my_view(request):
+        return http.HttpResponse(status=200, content="Success!")
+
+    urlpatterns = (urls.path("test/view", my_view, name="test_view"),)
+    django_set_urlconf(urlpatterns)
+    assert b'Success!' in client.get("/test/view").content


### PR DESCRIPTION
Currently overriding the Django urlconf requires a marker, which also requires defining the urlconf at the root of the test module. If you have many tests that need this (with differing patterns and views) this can get quite annoying. 

This doesn't seem to be necessary, as the Django urlconf setting can be an object and it can be changed at runtime.

This PR adds a `django_set_urlconf` fixture that allows you to define the urlconf within the test and set it directly with the fixture:

```python
def test_django_set_urlconf(django_set_urlconf, client) -> None:
    def my_view(request):
        return http.HttpResponse(status=200, content="Success!")

    urlpatterns = (urls.path("test/view", my_view, name="test_view"),)
    django_set_urlconf(urlpatterns)
    assert b'Success!' in client.get("test_view").content
```