### PR TITLE
Improve the contribution docs, add a test-sqlite make command and fix tox.ini errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,30 +23,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    env:
-      TEST_DB_USER: "test"
-      TEST_DB_PASSWORD: "test"
-    services:
-      mysql:
-        image: mysql:5.7
-        ports:
-          - 33306:3306
-        env:
-          MYSQL_USER: ${{ env.TEST_DB_USER }}
-          MYSQL_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      postgres:
-        image: postgres
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: ${{ env.TEST_DB_USER }}
-          POSTGRES_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - uses: actions/checkout@v3
         with:
@@ -55,6 +31,23 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+
+      - name: Setup mysql
+        if: contains(matrix.name, 'mysql')
+        timeout-minutes: 1
+        run: |
+          sudo systemctl start mysql.service
+          echo "TEST_DB_USER=root" >> $GITHUB_ENV
+          echo "TEST_DB_PASSWORD=root" >> $GITHUB_ENV
+          until mysqladmin pin; do sleep 1; done
+
+      - name: Setup postgresql
+        if: contains(matrix.name, 'postgres')
+        timeout-minutes: 1
+        run: |
+          sudo systemctl start postgresql.service
+          sudo -u postgres createuser --createdb $USER
+          until pg_isready; do sleep 1; done
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,30 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+    env:
+      TEST_DB_USER: "test"
+      TEST_DB_PASSWORD: "test"
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - 33306:3306
+        env:
+          MYSQL_USER: ${{ env.TEST_DB_USER }}
+          MYSQL_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: ${{ env.TEST_DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.TEST_DB_PASSWORD }}
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v3
         with:
@@ -32,23 +56,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Setup mysql
-        if: contains(matrix.name, 'mysql')
-        run: |
-          sudo systemctl start mysql.service
-          echo "TEST_DB_USER=root" >> $GITHUB_ENV
-          echo "TEST_DB_PASSWORD=root" >> $GITHUB_ENV
-
-      - name: Setup postgresql
-        if: contains(matrix.name, 'postgres')
-        run: |
-          sudo systemctl start postgresql.service
-          sudo -u postgres createuser --createdb $USER
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox==3.25.1
+          pip install tox
 
       - name: Run tox
         run: tox -e ${{ matrix.name }}

--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,8 @@ docs:
 isort:
 	isort pytest_django pytest_django_test tests
 
+test-sqlite: $(VENV)/bin/pytest
+	$(VENV)/bin/tox -e py310-stable-sqlite
+
 clean:
 	rm -rf bin include/ lib/ man/ pytest_django.egg-info/ build/

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -114,21 +114,18 @@ Running the tests
 There is a Makefile in the repository which aids in setting up a virtualenv
 and running the tests::
 
-    $ make test
-
-You can manually create the virtualenv using::
-
-    $ make testenv
+    $ make test-sqlite
 
 This will install a virtualenv with pytest and the latest stable version of
-Django. The virtualenv can then be activated with::
+Django, then run the basic sqlite tests.
+
+The virtualenv can then be activated with::
 
     $ source bin/activate
 
 Then, simply invoke pytest to run the test suite::
 
     $ pytest --ds=pytest_django_test.settings_sqlite
-
 
 tox can be used to run the test suite under different configurations by
 invoking::

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
 extras = testing
 deps =
     djmain: https://github.com/django/django/archive/main.tar.gz
+    stable: Django
     dj42: Django>=4.2,<4.3
     dj41: Django>=4.1,<4.2
     dj32: Django>=3.2,<4.0
@@ -39,7 +40,7 @@ setenv =
     coverage: COVERAGE_FILE={toxinidir}/.coverage
     coverage: PYTESTDJANGO_COVERAGE_SRC={toxinidir}/
 
-passenv = PYTEST_ADDOPTS TERM TEST_DB_USER TEST_DB_PASSWORD TEST_DB_HOST
+passenv = PYTEST_ADDOPTS,TERM,TEST_DB_USER,TEST_DB_PASSWORD,TEST_DB_HOST
 usedevelop = True
 commands =
     coverage: coverage erase


### PR DESCRIPTION
I noticed a few issues while bootstrapping this project for contributions. I ran into a tox error with some `tox.ini` values:

```
tox.tox_env.errors.Fail: pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'PYTEST_ADDOPTS TERM TEST_DB_USER TEST_DB_PASSWORD TEST_DB_HOST'
```

`make testenv` has also been removed, and I added a `make test-sqlite` command that bootstraps everything and runs the tests on the latest stable version of Django.  