### PR TITLE
Expose available_apps in django_db marker

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -84,6 +84,22 @@ dynamically in a hook or fixture.
 
     Note that this will slow down that test suite by approximately 3x.
 
+  :type available_apps: Union[List[str], None]
+  :param available_apps:
+    .. caution::
+
+      This argument is **experimental** and is subject to change without
+      deprecation.
+
+    The ``available_apps`` argument defines a subset of apps that are enabled
+    for a specific set of tests. Setting ``available_apps`` configures models
+    for which types/permissions will be created before each test, and which
+    model tables will be emptied after each test (this truncation may cascade
+    to unavailable apps models).
+
+    For details see :py:attr:`django.test.TransactionTestCase.available_apps`
+
+
 .. note::
 
   If you want access to the Django database inside a *fixture*, this marker may

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -157,7 +157,7 @@ def _django_db_helper(
             reset_sequences,
             databases,
             serialized_rollback,
-            available_apps
+            available_apps,
         ) = validate_django_db(marker)
     else:
         (
@@ -165,7 +165,7 @@ def _django_db_helper(
             reset_sequences,
             databases,
             serialized_rollback,
-            available_apps
+            available_apps,
         ) = False, False, None, False, None
 
     transactional = transactional or reset_sequences or (

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -18,8 +18,9 @@ if TYPE_CHECKING:
     import django
 
     _DjangoDbDatabases = Optional[Union["Literal['__all__']", Iterable[str]]]
-    # transaction, reset_sequences, databases, serialized_rollback
-    _DjangoDb = Tuple[bool, bool, _DjangoDbDatabases, bool]
+    _DjangoDbAvailableApps = Optional[List[str]]
+    # transaction, reset_sequences, databases, serialized_rollback, available_apps
+    _DjangoDb = Tuple[bool, bool, _DjangoDbDatabases, bool, _DjangoDbAvailableApps]
 
 
 __all__ = [
@@ -156,6 +157,7 @@ def _django_db_helper(
             reset_sequences,
             databases,
             serialized_rollback,
+            available_apps
         ) = validate_django_db(marker)
     else:
         (
@@ -163,7 +165,8 @@ def _django_db_helper(
             reset_sequences,
             databases,
             serialized_rollback,
-        ) = False, False, None, False
+            available_apps
+        ) = False, False, None, False, None
 
     transactional = transactional or reset_sequences or (
         "transactional_db" in request.fixturenames
@@ -190,12 +193,15 @@ def _django_db_helper(
     _reset_sequences = reset_sequences
     _serialized_rollback = serialized_rollback
     _databases = databases
+    _available_apps = available_apps
 
     class PytestDjangoTestCase(test_case_class):  # type: ignore[misc,valid-type]
         reset_sequences = _reset_sequences
         serialized_rollback = _serialized_rollback
         if _databases is not None:
             databases = _databases
+        if _available_apps is not None:
+            available_apps = _available_apps
 
         # For non-transactional tests, skip executing `django.test.TestCase`'s
         # `setUpClass`/`tearDownClass`, only execute the super class ones.
@@ -237,11 +243,12 @@ def validate_django_db(marker) -> "_DjangoDb":
     """Validate the django_db marker.
 
     It checks the signature and creates the ``transaction``,
-    ``reset_sequences``, ``databases`` and ``serialized_rollback`` attributes on
-    the marker which will have the correct values.
+    ``reset_sequences``, ``databases``, ``serialized_rollback`` and
+    ``available_apps`` attributes on the marker which will have the correct
+    values.
 
-    Sequence reset and serialized_rollback are only allowed when combined with
-    transaction.
+    Sequence reset, serialized_rollback, and available_apps are only allowed
+    when combined with transaction.
     """
 
     def apifun(
@@ -249,8 +256,9 @@ def validate_django_db(marker) -> "_DjangoDb":
         reset_sequences: bool = False,
         databases: "_DjangoDbDatabases" = None,
         serialized_rollback: bool = False,
+        available_apps: "_DjangoDbAvailableApps" = None,
     ) -> "_DjangoDb":
-        return transaction, reset_sequences, databases, serialized_rollback
+        return transaction, reset_sequences, databases, serialized_rollback, available_apps
 
     return apifun(*marker.args, **marker.kwargs)
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -389,7 +389,7 @@ def pytest_collection_modifyitems(items: List[pytest.Item]) -> None:
                     reset_sequences,
                     databases,
                     serialized_rollback,
-                    available_apps
+                    available_apps,
                 ) = validate_django_db(marker_db)
                 uses_db = True
                 transactional = transaction or reset_sequences

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -389,6 +389,7 @@ def pytest_collection_modifyitems(items: List[pytest.Item]) -> None:
                     reset_sequences,
                     databases,
                     serialized_rollback,
+                    available_apps
                 ) = validate_django_db(marker_db)
                 uses_db = True
                 transactional = transaction or reset_sequences


### PR DESCRIPTION
Right now in a multi-schema environment, TransactionTestCases may fail to flush if there are foreign key dependencies between schemas because the test case will flush the DB in `_fixture_teardown` (see [source](https://github.com/django/django/blob/24068058a63c506c300629fcc491601abc968926/django/test/testcases.py#L1135-L1143)) but will not cascade truncation by default.

I've encountered this issue in a multi-tenant environment, and another user has posted about a similar issue [here](https://forum.djangoproject.com/t/transactiontestcase-available-apps-allow-cascade-true-db-cannot-be-flushed/18111).

Setting `available_apps` will enable `CASCADE` during truncation per the django docs ([link](https://docs.djangoproject.com/en/4.1/topics/testing/advanced/#django.test.TransactionTestCase.available_apps))

This PR exposes `available_apps` so that this experimental feature of `TransactionTestCase` can be used in `pytest-django` directly.

Addresses https://github.com/pytest-dev/pytest-django/issues/928