### PR TITLE
Drop support for Python 3.7 (EOL since June 2023)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,21 +97,21 @@ jobs:
           python: '3.8'
           allow_failure: false
 
-        - name: py37-dj32-sqlite-xdist-coverage
-          python: '3.7'
+        - name: py38-dj32-sqlite-xdist-coverage
+          python: '3.8'
           allow_failure: false
 
         - name: py310-djmain-sqlite-coverage
           python: '3.10'
           allow_failure: true
 
-        - name: py37-dj32-mysql_myisam-coverage
-          python: '3.7'
+        - name: py38-dj32-mysql_myisam-coverage
+          python: '3.8'
           allow_failure: false
 
         # Explicitly test min pytest.
-        - name: py37-dj32-sqlite-pytestmin-coverage
-          python: '3.7'
+        - name: py38-dj32-sqlite-pytestmin-coverage
+          python: '3.8'
           allow_failure: false
 
         # pypy3: not included with coverage reports (much slower then).

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ pytest-django allows you to test your Django project/applications with the
 
   * Django: 3.2, 4.0, 4.1, 4.2 and latest main branch (compatible at the time of
     each release)
-  * Python: CPython>=3.7 or PyPy 3
+  * Python: CPython>=3.8 or PyPy 3
   * pytest: >=5.4
 
   For compatibility with older versions, use the pytest-django 3.*.* series.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -140,9 +140,9 @@ writing), running them all will take a long time. All valid configurations can
 be found in `tox.ini`. To test against a few of them, invoke tox with the `-e`
 flag::
 
-    $ tox -e py37-dj32-postgres,py310-dj41-mysql_innodb
+    $ tox -e py38-dj32-postgres,py310-dj41-mysql_innodb
 
-This will run the tests on Python 3.7/Django 3.2/PostgeSQL and Python
+This will run the tests on Python 3.8/Django 3.2/PostgeSQL and Python
 3.10/Django 4.1/MySQL.
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ testpaths = tests
 # W503 line break before binary operator
 ignore = W503
 max-line-length = 99
-exclude = lib/,src/,docs/,bin/
+exclude = lib/,src/,docs/,bin/,pytest_django/_version.py
 
 [isort]
 forced_separate = tests,pytest_django,pytest_django_test
@@ -74,6 +74,7 @@ include_trailing_comma = true
 line_length = 79
 multi_line_output = 5
 lines_after_imports = 2
+extend_skip = pytest_django/_version.py
 
 [mypy]
 check_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -34,7 +33,7 @@ project_urls =
 
 [options]
 packages = pytest_django
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm>=5.0.0
 install_requires = pytest>=5.4.0
 zip_safe = no


### PR DESCRIPTION
Someone needs to adjust this project's Required Checks to drop the 3.7 requirement :)