### PR TITLE
Make sure InvalidVarException.fail is reset

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -639,7 +639,7 @@ def _fail_for_invalid_template_variable():
 
 
 @pytest.fixture(autouse=True)
-def _template_string_if_invalid_marker(request) -> None:
+def _template_string_if_invalid_marker(monkeypatch, request) -> None:
     """Apply the @pytest.mark.ignore_template_errors marker,
      internal to pytest-django."""
     marker = request.keywords.get("ignore_template_errors", None)
@@ -648,7 +648,11 @@ def _template_string_if_invalid_marker(request) -> None:
             from django.conf import settings as dj_settings
 
             if dj_settings.TEMPLATES:
-                dj_settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"].fail = False
+                monkeypatch.setattr(
+                    dj_settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"],
+                    "fail",
+                    False,
+                )
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -628,14 +628,20 @@ def _fail_for_invalid_template_variable():
             else:
                 return msg
 
-    if (
-        os.environ.get(INVALID_TEMPLATE_VARS_ENV, "false") == "true"
-        and django_settings_is_configured()
-    ):
-        from django.conf import settings as dj_settings
+    with pytest.MonkeyPatch.context() as mp:
+        if (
+            os.environ.get(INVALID_TEMPLATE_VARS_ENV, "false") == "true"
+            and django_settings_is_configured()
+        ):
+            from django.conf import settings as dj_settings
 
-        if dj_settings.TEMPLATES:
-            dj_settings.TEMPLATES[0]["OPTIONS"]["string_if_invalid"] = InvalidVarException()
+            if dj_settings.TEMPLATES:
+                mp.setitem(
+                    dj_settings.TEMPLATES[0]["OPTIONS"],
+                    "string_if_invalid",
+                    InvalidVarException(),
+                )
+        yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
after a test using ignore_template_errors marker.

Otherwise, the first test set `fail` to `False`, never to be changed again.