### PR TITLE
Show Django's version in the django report header

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -367,6 +367,11 @@ def pytest_configure() -> None:
 @pytest.hookimpl()
 def pytest_report_header(config: pytest.Config) -> Optional[List[str]]:
     report_header = config.stash[report_header_key]
+
+    if "django" in sys.modules:
+        import django
+        report_header.insert(0, f"version: {django.get_version()}")
+
     if report_header:
         return ["django: " + ", ".join(report_header)]
     return None

--- a/tests/test_django_configurations.py
+++ b/tests/test_django_configurations.py
@@ -42,7 +42,8 @@ def test_dc_env(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -> N
     )
     result = pytester.runpytest_subprocess()
     result.stdout.fnmatch_lines([
-        'django: settings: tpkg.settings_env (from env), configuration: MySettings (from env)',
+        "django: version: *, settings: tpkg.settings_env (from env), "
+        "configuration: MySettings (from env)",
         "* 1 passed*",
     ])
     assert result.ret == 0
@@ -73,7 +74,8 @@ def test_dc_env_overrides_ini(pytester: pytest.Pytester, monkeypatch: pytest.Mon
     )
     result = pytester.runpytest_subprocess()
     result.stdout.fnmatch_lines([
-        'django: settings: tpkg.settings_env (from env), configuration: MySettings (from env)',
+        "django: version: *, settings: tpkg.settings_env (from env), "
+        "configuration: MySettings (from env)",
         "* 1 passed*",
     ])
     assert result.ret == 0
@@ -103,7 +105,8 @@ def test_dc_ini(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -> N
     )
     result = pytester.runpytest_subprocess()
     result.stdout.fnmatch_lines([
-        'django: settings: tpkg.settings_ini (from ini), configuration: MySettings (from ini)',
+        "django: version: *, settings: tpkg.settings_ini (from ini), "
+        "configuration: MySettings (from ini)",
         "* 1 passed*",
     ])
     assert result.ret == 0
@@ -134,7 +137,7 @@ def test_dc_option(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -
     )
     result = pytester.runpytest_subprocess("--ds=tpkg.settings_opt", "--dc=MySettings")
     result.stdout.fnmatch_lines([
-        'django: settings: tpkg.settings_opt (from option),'
+        'django: version: *, settings: tpkg.settings_opt (from option),'
         ' configuration: MySettings (from option)',
         "* 1 passed*",
     ])

--- a/tests/test_django_settings_module.py
+++ b/tests/test_django_settings_module.py
@@ -38,7 +38,7 @@ def test_ds_ini(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -> N
     )
     result = pytester.runpytest_subprocess()
     result.stdout.fnmatch_lines([
-        "django: settings: tpkg.settings_ini (from ini)",
+        "django: version: *, settings: tpkg.settings_ini (from ini)",
         "*= 1 passed*",
     ])
     assert result.ret == 0
@@ -59,7 +59,7 @@ def test_ds_env(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -> N
     )
     result = pytester.runpytest_subprocess()
     result.stdout.fnmatch_lines([
-        "django: settings: tpkg.settings_env (from env)",
+        "django: version: *, settings: tpkg.settings_env (from env)",
         "*= 1 passed*",
     ])
 
@@ -85,7 +85,7 @@ def test_ds_option(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch) -
     )
     result = pytester.runpytest_subprocess("--ds=tpkg.settings_opt")
     result.stdout.fnmatch_lines([
-        "django: settings: tpkg.settings_opt (from option)",
+        "django: version: *, settings: tpkg.settings_opt (from option)",
         "*= 1 passed*",
     ])
 


### PR DESCRIPTION
Fix #987.

Before:

```
platform linux -- Python 3.11.4, pytest-7.4.2, pluggy-1.3.0
django: settings: conf.settings (from ini)
rootdir: /my/project
configfile: pytest.ini
plugins: xdist-3.3.1, snapshot-0.9.0, django-4.5.3.dev49+g055f251
```

After:

```
platform linux -- Python 3.11.4, pytest-7.4.2, pluggy-1.3.0
django: version: 4.2.5, settings: conf.settings (from ini)
rootdir: /my/project
configfile: pytest.ini
plugins: xdist-3.3.1, snapshot-0.9.0, django-4.5.3.dev49+g055f251
```