### PR TITLE
Convert Django test tags to Pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ addopts = [
 ]
 DJANGO_SETTINGS_MODULE = "pytest_django_test.settings_sqlite_file"
 testpaths = ["tests"]
+markers = ["tag1", "tag2", "tag3", "tag4", "tag5"]
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
Django TestCase supports tags:
https://docs.djangoproject.com/en/4.2/topics/testing/tools/#topics-tagging-tests These are basically similar to (basic) Pytest tags, so let's interpret them to allow using the native pytest-native markers functionality. This helps projects which are unable to convert tags to markers.

This may cause breakage for projects using `strict-markers`. Such projects would need to add the tags to their `markers` config, or deal with it some other way.

Fix #818.