### PR TITLE
Maybe fix readthedocs build failures

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,8 +3,12 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
 python:
-   version: 3
    install:
       - method: pip
         path: .


### PR DESCRIPTION
Try to fix this error:

> Problem in your project's configuration. Invalid configuration option
> "build.os": build not found