### PR TITLE
Some more typing support for pytest-django fixtures

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -514,6 +514,14 @@ Example usage::
         assert mailoutbox[0].subject == 'Contact Form'
         assert mailoutbox[0].body == 'I like your site'
 
+If you use type annotations, you can annotate the fixture like this::
+
+    from pytest_django import DjangoCaptureOnCommitCallbacks
+
+    def test_on_commit(
+        django_capture_on_commit_callbacks: DjangoCaptureOnCommitCallbacks,
+    ):
+        ...
 
 .. fixture:: mailoutbox
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -447,6 +447,15 @@ Example usage::
 
         assert 'foo' in captured.captured_queries[0]['sql']
 
+If you use type annotations, you can annotate the fixture like this::
+
+    from pytest_django import DjangoAssertNumQueries
+
+    def test_num_queries(
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ):
+        ...
+
 
 .. fixture:: django_assert_max_num_queries
 
@@ -469,6 +478,15 @@ Example usage::
         with django_assert_max_num_queries(2):
             Item.objects.create('foo')
             Item.objects.create('bar')
+
+If you use type annotations, you can annotate the fixture like this::
+
+    from pytest_django import DjangoAssertNumQueries
+
+    def test_max_num_queries(
+        django_assert_max_num_queries: DjangoAssertNumQueries,
+    ):
+        ...
 
 
 .. fixture:: django_capture_on_commit_callbacks

--- a/pytest_django/__init__.py
+++ b/pytest_django/__init__.py
@@ -5,12 +5,13 @@ except ImportError:  # pragma: no cover
     __version__ = "unknown"
 
 
-from .fixtures import DjangoCaptureOnCommitCallbacks
+from .fixtures import DjangoAssertNumQueries, DjangoCaptureOnCommitCallbacks
 from .plugin import DjangoDbBlocker
 
 
 __all__ = [
     "__version__",
+    "DjangoAssertNumQueries",
     "DjangoCaptureOnCommitCallbacks",
     "DjangoDbBlocker",
 ]

--- a/pytest_django/__init__.py
+++ b/pytest_django/__init__.py
@@ -5,10 +5,12 @@ except ImportError:  # pragma: no cover
     __version__ = "unknown"
 
 
+from .fixtures import DjangoCaptureOnCommitCallbacks
 from .plugin import DjangoDbBlocker
 
 
 __all__ = [
     "__version__",
+    "DjangoCaptureOnCommitCallbacks",
     "DjangoDbBlocker",
 ]

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -601,12 +601,25 @@ def _live_server_helper(request: pytest.FixtureRequest) -> Generator[None, None,
     live_server._live_server_modified_settings.disable()
 
 
+class DjangoAssertNumQueries(Protocol):
+    """The type of the `django_assert_num_queries` and
+    `django_assert_max_num_queries` fixtures."""
+
+    def __call__(
+        self,
+        num: int,
+        connection: Any | None = ...,
+        info: str | None = ...,
+    ) -> django.test.utils.CaptureQueriesContext:
+        pass  # pragma: no cover
+
+
 @contextmanager
 def _assert_num_queries(
     config: pytest.Config,
     num: int,
     exact: bool = True,
-    connection=None,
+    connection: Any | None = None,
     info: str | None = None,
 ) -> Generator[django.test.utils.CaptureQueriesContext, None, None]:
     from django.test.utils import CaptureQueriesContext
@@ -641,12 +654,12 @@ def _assert_num_queries(
 
 
 @pytest.fixture()
-def django_assert_num_queries(pytestconfig: pytest.Config):
+def django_assert_num_queries(pytestconfig: pytest.Config) -> DjangoAssertNumQueries:
     return partial(_assert_num_queries, pytestconfig)
 
 
 @pytest.fixture()
-def django_assert_max_num_queries(pytestconfig: pytest.Config):
+def django_assert_max_num_queries(pytestconfig: pytest.Config) -> DjangoAssertNumQueries:
     return partial(_assert_num_queries, pytestconfig, exact=False)
 
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -7,12 +7,15 @@ from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     ClassVar,
+    ContextManager,
     Generator,
     Iterable,
     List,
     Literal,
     Optional,
+    Protocol,
     Tuple,
     Union,
 )
@@ -647,8 +650,20 @@ def django_assert_max_num_queries(pytestconfig: pytest.Config):
     return partial(_assert_num_queries, pytestconfig, exact=False)
 
 
+class DjangoCaptureOnCommitCallbacks(Protocol):
+    """The type of the `django_capture_on_commit_callbacks` fixture."""
+
+    def __call__(
+        self,
+        *,
+        using: str = ...,
+        execute: bool = ...,
+    ) -> ContextManager[list[Callable[[], Any]]]:
+        pass  # pragma: no cover
+
+
 @pytest.fixture()
-def django_capture_on_commit_callbacks():
+def django_capture_on_commit_callbacks() -> DjangoCaptureOnCommitCallbacks:
     from django.test import TestCase
 
-    return TestCase.captureOnCommitCallbacks
+    return TestCase.captureOnCommitCallbacks  # type: ignore[no-any-return]

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -18,6 +18,7 @@ from django.utils.encoding import force_str
 
 from .helpers import DjangoPytester
 
+from pytest_django import DjangoDbBlocker
 from pytest_django_test.app.models import Item
 
 
@@ -690,7 +691,7 @@ class Migration(migrations.Migration):
 
 class Test_django_db_blocker:
     @pytest.mark.django_db
-    def test_block_manually(self, django_db_blocker) -> None:
+    def test_block_manually(self, django_db_blocker: DjangoDbBlocker) -> None:
         try:
             django_db_blocker.block()
             with pytest.raises(RuntimeError):
@@ -699,19 +700,19 @@ class Test_django_db_blocker:
             django_db_blocker.restore()
 
     @pytest.mark.django_db
-    def test_block_with_block(self, django_db_blocker) -> None:
+    def test_block_with_block(self, django_db_blocker: DjangoDbBlocker) -> None:
         with django_db_blocker.block():
             with pytest.raises(RuntimeError):
                 Item.objects.exists()
 
-    def test_unblock_manually(self, django_db_blocker) -> None:
+    def test_unblock_manually(self, django_db_blocker: DjangoDbBlocker) -> None:
         try:
             django_db_blocker.unblock()
             Item.objects.exists()
         finally:
             django_db_blocker.restore()
 
-    def test_unblock_with_block(self, django_db_blocker) -> None:
+    def test_unblock_with_block(self, django_db_blocker: DjangoDbBlocker) -> None:
         with django_db_blocker.unblock():
             Item.objects.exists()
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -18,7 +18,7 @@ from django.utils.encoding import force_str
 
 from .helpers import DjangoPytester
 
-from pytest_django import DjangoCaptureOnCommitCallbacks, DjangoDbBlocker
+from pytest_django import DjangoAssertNumQueries, DjangoCaptureOnCommitCallbacks, DjangoDbBlocker
 from pytest_django_test.app.models import Item
 
 
@@ -91,7 +91,7 @@ def test_async_rf(async_rf: AsyncRequestFactory) -> None:
 @pytest.mark.django_db
 def test_django_assert_num_queries_db(
     request: pytest.FixtureRequest,
-    django_assert_num_queries,
+    django_assert_num_queries: DjangoAssertNumQueries,
 ) -> None:
     with nonverbose_config(request.config):
         with django_assert_num_queries(3):
@@ -111,7 +111,7 @@ def test_django_assert_num_queries_db(
 @pytest.mark.django_db
 def test_django_assert_max_num_queries_db(
     request: pytest.FixtureRequest,
-    django_assert_max_num_queries,
+    django_assert_max_num_queries: DjangoAssertNumQueries,
 ) -> None:
     with nonverbose_config(request.config):
         with django_assert_max_num_queries(2):
@@ -134,7 +134,9 @@ def test_django_assert_max_num_queries_db(
 
 @pytest.mark.django_db(transaction=True)
 def test_django_assert_num_queries_transactional_db(
-    request: pytest.FixtureRequest, transactional_db: None, django_assert_num_queries
+    request: pytest.FixtureRequest,
+    transactional_db: None,
+    django_assert_num_queries: DjangoAssertNumQueries,
 ) -> None:
     with nonverbose_config(request.config):
         with transaction.atomic():
@@ -187,7 +189,9 @@ def test_django_assert_num_queries_output_verbose(django_pytester: DjangoPyteste
 
 
 @pytest.mark.django_db
-def test_django_assert_num_queries_db_connection(django_assert_num_queries) -> None:
+def test_django_assert_num_queries_db_connection(
+    django_assert_num_queries: DjangoAssertNumQueries,
+) -> None:
     from django.db import connection
 
     with django_assert_num_queries(1, connection=connection):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -18,7 +18,7 @@ from django.utils.encoding import force_str
 
 from .helpers import DjangoPytester
 
-from pytest_django import DjangoDbBlocker
+from pytest_django import DjangoCaptureOnCommitCallbacks, DjangoDbBlocker
 from pytest_django_test.app.models import Item
 
 
@@ -232,7 +232,9 @@ def test_django_assert_num_queries_output_info(django_pytester: DjangoPytester) 
 
 
 @pytest.mark.django_db
-def test_django_capture_on_commit_callbacks(django_capture_on_commit_callbacks) -> None:
+def test_django_capture_on_commit_callbacks(
+    django_capture_on_commit_callbacks: DjangoCaptureOnCommitCallbacks,
+) -> None:
     if not connection.features.supports_transactions:
         pytest.skip("transactions required for this test")
 
@@ -255,7 +257,9 @@ def test_django_capture_on_commit_callbacks(django_capture_on_commit_callbacks) 
 
 
 @pytest.mark.django_db(databases=["default", "second"])
-def test_django_capture_on_commit_callbacks_multidb(django_capture_on_commit_callbacks) -> None:
+def test_django_capture_on_commit_callbacks_multidb(
+    django_capture_on_commit_callbacks: DjangoCaptureOnCommitCallbacks,
+) -> None:
     if not connection.features.supports_transactions:
         pytest.skip("transactions required for this test")
 
@@ -282,7 +286,7 @@ def test_django_capture_on_commit_callbacks_multidb(django_capture_on_commit_cal
 
 @pytest.mark.django_db(transaction=True)
 def test_django_capture_on_commit_callbacks_transactional(
-    django_capture_on_commit_callbacks,
+    django_capture_on_commit_callbacks: DjangoCaptureOnCommitCallbacks,
 ) -> None:
     if not connection.features.supports_transactions:
         pytest.skip("transactions required for this test")


### PR DESCRIPTION
For users (like me) who like to type annotate their tests, this adds types in `pytest_django` for typing the `django_capture_on_commit_callbacks`, `django_assert_num_queries` and `django_assert_max_num_queries` fixtures (in addition to `django_db_blocker` from a previous PR).