### PR TITLE
 tests: make it possible to run without setting `PYTHONPATH=$(pwd)`

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -163,7 +163,7 @@ but please don't include them in your pull requests.
 
 After this short initial setup you're ready to run tests::
 
-    $ COVERAGE_PROCESS_START=`pwd`/pyproject.toml COVERAGE_FILE=`pwd`/.coverage PYTHONPATH=`pwd` pytest --ds=pytest_django_test.settings_postgres
+    $ COVERAGE_PROCESS_START=`pwd`/pyproject.toml COVERAGE_FILE=`pwd`/.coverage pytest --ds=pytest_django_test.settings_postgres
 
 You should repeat the above step for sqlite and mysql before the next step.
 This step will create a lot of ``.coverage`` files with additional suffixes for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ addopts = [
     # Show extra test summary info for everything.
     "-ra",
 ]
+pythonpath = ["."]
 DJANGO_SETTINGS_MODULE = "pytest_django_test.settings_sqlite_file"
 testpaths = ["tests"]
 markers = ["tag1", "tag2", "tag3", "tag4", "tag5"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import os
 import pathlib
 import shutil
 from pathlib import Path
@@ -134,6 +135,11 @@ def django_pytester(
     # Copy the test app to make it available in the new test run
     shutil.copytree(str(app_source), str(test_app_path))
     tpkg_path.joinpath("the_settings.py").write_text(test_settings)
+
+    # For suprocess tests, pytest's `pythonpath` setting doesn't currently
+    # work, only the envvar does.
+    pythonpath = os.pathsep.join(filter(None, [str(REPOSITORY_ROOT), os.getenv("PYTHONPATH", "")]))
+    monkeypatch.setenv("PYTHONPATH", pythonpath)
 
     monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tpkg.the_settings")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from .helpers import DjangoPytester
 
 pytest_plugins = "pytester"
 
-REPOSITORY_ROOT = pathlib.Path(__file__).parent
+REPOSITORY_ROOT = pathlib.Path(__file__).parent.parent
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -128,7 +128,7 @@ def django_pytester(
 
     tpkg_path.joinpath("__init__.py").touch()
 
-    app_source = REPOSITORY_ROOT / "../pytest_django_test/app"
+    app_source = REPOSITORY_ROOT / "pytest_django_test/app"
     test_app_path = tpkg_path / "app"
 
     # Copy the test app to make it available in the new test run

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,6 @@ deps =
     xdist: pytest-xdist>=1.15
 
 setenv =
-    PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}
-
     mysql_innodb: DJANGO_SETTINGS_MODULE=pytest_django_test.settings_mysql_innodb
     mysql_myisam: DJANGO_SETTINGS_MODULE=pytest_django_test.settings_mysql_myisam
     postgres:     DJANGO_SETTINGS_MODULE=pytest_django_test.settings_postgres


### PR DESCRIPTION
This makes just `pytest` run successfully.