### PR TITLE
Set MIGRATE setting properly when disabling migrations

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -298,7 +298,7 @@ def _disable_migrations() -> None:
 
     settings.MIGRATION_MODULES = DisableMigrations()
     # MIGRATE setting added in Django 3.1
-    # https://docs.djangoproject.com/en/dev/ref/settings/#std-setting-TEST_MIGRATE
+    # https://docs.djangoproject.com/en/dev/ref/settings/#migrate
     settings.MIGRATE = False
 
     class MigrateSilentCommand(migrate.Command):

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -297,6 +297,9 @@ def _disable_migrations() -> None:
             return None
 
     settings.MIGRATION_MODULES = DisableMigrations()
+    # MIGRATE setting added in Django 3.1
+    # https://docs.djangoproject.com/en/dev/ref/settings/#std-setting-TEST_MIGRATE
+    settings.MIGRATE = False
 
     class MigrateSilentCommand(migrate.Command):
         def handle(self, *args, **kwargs):


### PR DESCRIPTION
Heyo, hopefully an easy picking. See https://docs.djangoproject.com/en/3.1/ref/settings/#migrate for the setting's introduction.

BTW, my main motivation to set this setting is to allow easy conditional skipping of tests.