### PR TITLE
Fixed changelog.rst typo and added link to Django documentation.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,8 +7,8 @@ v4.8.0 (2024-01-30)
 Improvements
 ^^^^^^^^^^^^
 
-* Add `pytest.asserts.assertMessages()` to mimic the behaviour of the
-  ``django.contrib.messages.test.MessagesTestMixin.assertMessages`` function
+* Added ``pytest_django.asserts.assertMessages()`` to mimic the behaviour of the
+  :meth:`~django.contrib.messages.test.MessagesTestMixin.assertMessages` method
   for Django versions >= 5.0.
 
 Bugfixes


### PR DESCRIPTION
Just saw a little typo in the changelog I added, and added an intersphinx link. Great to see the quick release!