### PR TITLE
fail-on-template-vars: be more discreet with ignore_template_errors

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -644,8 +644,9 @@ def _fail_for_invalid_template_variable():
     class InvalidVarException:
         """Custom handler for invalid strings in templates."""
 
-        def __init__(self) -> None:
+        def __init__(self, *, origin_value: str = "") -> None:
             self.fail = True
+            self.origin_value = origin_value
 
         def __contains__(self, key: str) -> bool:
             return key == "%s"
@@ -696,7 +697,7 @@ def _fail_for_invalid_template_variable():
             if self.fail:
                 pytest.fail(msg)
             else:
-                return msg
+                return self.origin_value
 
     with pytest.MonkeyPatch.context() as mp:
         if (
@@ -709,7 +710,11 @@ def _fail_for_invalid_template_variable():
                 mp.setitem(
                     dj_settings.TEMPLATES[0]["OPTIONS"],
                     "string_if_invalid",
-                    InvalidVarException(),
+                    InvalidVarException(
+                        origin_value=dj_settings.TEMPLATES[0]["OPTIONS"].get(
+                            "string_if_invalid", ""
+                        )
+                    ),
                 )
         yield
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -644,7 +644,7 @@ def _fail_for_invalid_template_variable():
     class InvalidVarException:
         """Custom handler for invalid strings in templates."""
 
-        def __init__(self, *, origin_value: str = "") -> None:
+        def __init__(self, *, origin_value: str) -> None:
             self.fail = True
             self.origin_value = origin_value
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -150,6 +150,50 @@ def test_invalid_template_variable_marker_cleanup(django_pytester: DjangoPyteste
         'django.template.loaders.filesystem.Loader',
         'django.template.loaders.app_directories.Loader',
     )
+    TEMPLATES[0]["OPTIONS"]["string_if_invalid"] = "Something clever"
+    """
+)
+def test_invalid_template_variable_behaves_normally_when_ignored(
+    django_pytester: DjangoPytester
+) -> None:
+    django_pytester.create_app_file(
+        "<div>{{ invalid_var }}</div>", "templates/invalid_template_base.html"
+    )
+    django_pytester.create_app_file(
+        "{% include 'invalid_template_base.html' %}", "templates/invalid_template.html"
+    )
+    django_pytester.create_test_module(
+        """
+        from django.template.loader import render_to_string
+
+        import pytest
+
+        @pytest.mark.ignore_template_errors
+        def test_ignore(client):
+            assert render_to_string('invalid_template.html') == "<div>Something clever</div>"
+
+        def test_for_invalid_template(client):
+            render_to_string('invalid_template.html')
+
+        """
+    )
+    result = django_pytester.runpytest_subprocess("-s", "--fail-on-template-vars")
+
+    origin = "'*/tpkg/app/templates/invalid_template_base.html'"
+    result.stdout.fnmatch_lines_random(
+        [
+            "tpkg/test_the_test.py .F*",
+            f"E * Failed: Undefined template variable 'invalid_var' in {origin}",
+        ]
+    )
+
+
+@pytest.mark.django_project(
+    extra_settings="""
+    TEMPLATE_LOADERS = (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    )
     ROOT_URLCONF = 'tpkg.app.urls'
     """
 )


### PR DESCRIPTION
When using the `@pytest.mark.ignore_template_errors` on a test, we could expect the test to return to its original behavior (just like running them without `--fail-on-template-vars`).

This would ease the use of the option since ignored tests are less likely to crash.