### PR TITLE
Added import to database documentation sample code

### DIFF
--- a/docs/database.rst
+++ b/docs/database.rst
@@ -370,6 +370,8 @@ Put this into ``conftest.py``::
 
     @pytest.fixture(scope='session')
     def django_db_setup():
+        from django.conf import settings
+
         settings.DATABASES['default'] = {
             'ENGINE': 'django.db.backends.mysql',
             'HOST': 'db.example.com',


### PR DESCRIPTION
This PR updates a code sample in the documentation when using an existing database for the tests.

I ran across this omission when setting up my own project... I copied the original sample code into my project, and then Python complained that the `settings.DATABASES` was not defined.
So I added a one-liner `from django.conf import settings` to the code sample, and now it runs as is.