### PR TITLE
Add docstrings to public fixtures

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -656,11 +656,13 @@ def _assert_num_queries(
 
 @pytest.fixture()
 def django_assert_num_queries(pytestconfig: pytest.Config) -> DjangoAssertNumQueries:
+    """Allows to check for an expected number of DB queries."""
     return partial(_assert_num_queries, pytestconfig)
 
 
 @pytest.fixture()
 def django_assert_max_num_queries(pytestconfig: pytest.Config) -> DjangoAssertNumQueries:
+    """Allows to check for an expected maximum number of DB queries."""
     return partial(_assert_num_queries, pytestconfig, exact=False)
 
 
@@ -678,6 +680,7 @@ class DjangoCaptureOnCommitCallbacks(Protocol):
 
 @pytest.fixture()
 def django_capture_on_commit_callbacks() -> DjangoCaptureOnCommitCallbacks:
+    """Captures transaction.on_commit() callbacks for the given database connection."""
     from django.test import TestCase
 
     return TestCase.captureOnCommitCallbacks  # type: ignore[no-any-return]

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -94,22 +94,26 @@ def django_db_modify_db_settings_parallel_suffix(
 def django_db_modify_db_settings(
     django_db_modify_db_settings_parallel_suffix: None,
 ) -> None:
+    """Modify db settings just before the databases are configured."""
     skip_if_no_django()
 
 
 @pytest.fixture(scope="session")
 def django_db_use_migrations(request: pytest.FixtureRequest) -> bool:
+    """Return whether to use migrations to create the test databases."""
     return not request.config.getvalue("nomigrations")
 
 
 @pytest.fixture(scope="session")
 def django_db_keepdb(request: pytest.FixtureRequest) -> bool:
+    """Return whether to re-use an existing database and to keep it after the test run."""
     reuse_db: bool = request.config.getvalue("reuse_db")
     return reuse_db
 
 
 @pytest.fixture(scope="session")
 def django_db_createdb(request: pytest.FixtureRequest) -> bool:
+    """Return whether the database is to be re-created before running any tests."""
     create_db: bool = request.config.getvalue("create_db")
     return create_db
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -578,6 +578,7 @@ def mailoutbox(
     django_mail_patch_dns: None,
     _dj_autoclear_mailbox: None,
 ) -> list[django.core.mail.EmailMessage] | None:
+    """A clean email outbox to which Django-generated emails are sent."""
     if not django_settings_is_configured():
         return None
 
@@ -591,6 +592,7 @@ def django_mail_patch_dns(
     monkeypatch: pytest.MonkeyPatch,
     django_mail_dnsname: str,
 ) -> None:
+    """Patch the server dns name used in email messages."""
     from django.core import mail
 
     monkeypatch.setattr(mail.message, "DNS_NAME", django_mail_dnsname)
@@ -598,6 +600,7 @@ def django_mail_patch_dns(
 
 @pytest.fixture()
 def django_mail_dnsname() -> str:
+    """Return server dns name for using in email messages."""
     return "fake-tests.example.com"
 
 


### PR DESCRIPTION
This PR adds short docstrings to quickly check available fixtures and is especially usefull for new pytest-django users.

I've noticed that some public fixtures don't have docstrings to give the ability to quickly check what this fixture does.
For example, the command `pytest --fixtures`  shows builtin and custom fixtures with their short descriptions, but pytest-django doesn't provide them all:
```
...
-------------------------------------------------------------- fixtures defined from pytest_django.plugin --------------------------------------------------------------- 
django_test_environment [session scope] -- pytest_django\plugin.py:479
    Setup Django's test environment for the testing session.

django_db_blocker [session scope] -- pytest_django\plugin.py:507
    Wrapper around Django's database access.

mailoutbox -- pytest_django\plugin.py:577
    no docstring available

django_mail_patch_dns -- pytest_django\plugin.py:590
    no docstring available

django_mail_dnsname -- pytest_django\plugin.py:600
    no docstring available
...
```
After docstrings update:
```
pytest --fixtures
...
-------------------------------------------------------------- fixtures defined from pytest_django.plugin --------------------------------------------------------------- 
django_test_environment [session scope] -- pytest_django\plugin.py:479
    Setup Django's test environment for the testing session.

django_db_blocker [session scope] -- pytest_django\plugin.py:507
    Wrapper around Django's database access.

mailoutbox -- pytest_django\plugin.py:577
    A clean email outbox to which Django-generated emails are sent.

django_mail_patch_dns -- pytest_django\plugin.py:591
    Patch the server dns name used in email messages.

django_mail_dnsname -- pytest_django\plugin.py:602
    Return server dns name for using in email messages.
...
```