### PR TITLE
Fix type hints for assertFormError and assertForSetError. Refs pytest-dev#1137

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Nicolas Delaby <ticosax@free.fr>
 Hasan Ramezani <hasan.r67@gmail.com>
 Michael Howitz
 Mark Gensler
+Pavel Taufer

--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -55,6 +55,7 @@ for assert_func in assertions_names:
 
 if TYPE_CHECKING:
     from django.http.response import HttpResponseBase
+    import django.forms as forms
 
     def assertRedirects(
         response: HttpResponseBase,
@@ -93,8 +94,7 @@ if TYPE_CHECKING:
         ...
 
     def assertFormError(
-        response: HttpResponseBase,
-        form: str,
+        form: forms.BaseForm,
         field: str | None,
         errors: str | Sequence[str],
         msg_prefix: str = ...,
@@ -102,8 +102,7 @@ if TYPE_CHECKING:
         ...
 
     def assertFormsetError(
-        response: HttpResponseBase,
-        formset: str,
+        formset: forms.BaseFormSet,
         form_index: int | None,
         field: str | None,
         errors: str | Sequence[str],

--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -101,7 +101,7 @@ if TYPE_CHECKING:
     ) -> None:
         ...
 
-    def assertFormsetError(
+    def assertFormSetError(
         formset: forms.BaseFormSet,
         form_index: int | None,
         field: str | None,


### PR DESCRIPTION
Fixes wrong type hints mentioned in https://github.com/pytest-dev/pytest-django/issues/1137