### PR TITLE
plugin: unconfigure should `restore` not `unblock`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: docs test clean fix
 
 test:
-	tox -e py311-dj42-sqlite_file
+	tox -e py-dj42-sqlite_file
 
 docs:
 	tox -e docs

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -845,6 +845,11 @@ class DjangoDbBlocker:
         return _DatabaseBlockerContextManager(self)
 
     def restore(self) -> None:
+        """Undo a previous call to block() or unblock().
+
+        Consider using block() and unblock() as context managers instead of
+        manually calling restore().
+        """
         self._dj_db_wrapper.ensure_connection = self._history.pop()
 
 


### PR DESCRIPTION
`restore` pops the `block` in `_setup_django`, while `unblock` pushes an unblock. We want to leave things clean, so should `restore`.