### PR TITLE
Adds using to assert_num_queries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,17 +103,21 @@ jobs:
           python: '3.9'
           allow_failure: false
 
+        - name: py312-djmain-sqlite-coverage
+          python: '3.12'
+          allow_failure: true
+
         - name: py312-dj51-sqlite-xdist-coverage
           python: '3.12'
+          allow_failure: false
+
+        - name: py311-dj42-sqlite-xdist-coverage
+          python: '3.11'
           allow_failure: false
 
         - name: py38-dj42-sqlite-xdist-coverage
           python: '3.8'
           allow_failure: false
-
-        - name: py311-djmain-sqlite-coverage
-          python: '3.11'
-          allow_failure: true
 
         - name: py311-dj42-mysql_myisam-coverage
           python: '3.11'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Compatibility
 ^^^^^^^^^^^^^
 
 * Added official support for Python 3.13.
+* Adds ``using`` argument to assert_num_query
 
 Bugfixes
 ^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,8 +9,9 @@ Compatibility
 
 * Added official support for Python 3.13.
 
-* Adds ``using`` argument to ``pytest_django.fixtures.django_assert_num_queries`` 
-  and `pytest_django.fixtures.django_assert_max_num_queries``
+* Added ``using`` argument to :fixture:`django_assert_num_queries` and
+  :fixture:`django_assert_max_num_queries` to easily specify the database
+  alias to use.
 
 Bugfixes
 ^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,9 @@ Compatibility
 ^^^^^^^^^^^^^
 
 * Added official support for Python 3.13.
-* Adds ``using`` argument to assert_num_query
+
+* Adds ``using`` argument to ``pytest_django.fixtures.django_assert_num_queries`` 
+  and `pytest_django.fixtures.django_assert_max_num_queries``
 
 Bugfixes
 ^^^^^^^^

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -466,9 +466,9 @@ If you use type annotations, you can annotate the fixture like this::
 .. py:function:: django_assert_max_num_queries(num, connection=None, info=None, using=None)
 
   :param num: expected maximum number of queries
-  :param connection: optional non-default DB connection
+  :param connection: optional database connection
   :param str info: optional info message to display on failure
-  :param str using: optional the non-default DB connection name
+  :param str using: optional database connection name
 
 This fixture allows to check for an expected maximum number of DB queries.
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -428,7 +428,7 @@ Example
   :param num: expected number of queries
   :param connection: optional database connection
   :param str info: optional info message to display on failure
-  :param str using: optional database connection name
+  :param str using: optional database alias
 
 This fixture allows to check for an expected number of DB queries.
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -423,7 +423,7 @@ Example
 ``django_assert_num_queries``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. py:function:: django_assert_num_queries(num, connection=None, info=None, using=None)
+.. py:function:: django_assert_num_queries(num, connection=None, info=None, *, using=None)
 
   :param num: expected number of queries
   :param connection: optional database connection

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -426,9 +426,9 @@ Example
 .. py:function:: django_assert_num_queries(num, connection=None, info=None, using=None)
 
   :param num: expected number of queries
-  :param connection: optional non-default DB connection
+  :param connection: optional database connection
   :param str info: optional info message to display on failure
-  :param str using: optional the non-default DB connection name
+  :param str using: optional database connection name
 
 This fixture allows to check for an expected number of DB queries.
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -423,11 +423,12 @@ Example
 ``django_assert_num_queries``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. py:function:: django_assert_num_queries(num, connection=None, info=None)
+.. py:function:: django_assert_num_queries(num, connection=None, info=None, using=None)
 
   :param num: expected number of queries
   :param connection: optional non-default DB connection
   :param str info: optional info message to display on failure
+  :param str using: optional the non-default DB connection name
 
 This fixture allows to check for an expected number of DB queries.
 
@@ -462,11 +463,12 @@ If you use type annotations, you can annotate the fixture like this::
 ``django_assert_max_num_queries``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. py:function:: django_assert_max_num_queries(num, connection=None, info=None)
+.. py:function:: django_assert_max_num_queries(num, connection=None, info=None, using=None)
 
   :param num: expected maximum number of queries
   :param connection: optional non-default DB connection
   :param str info: optional info message to display on failure
+  :param str using: optional the non-default DB connection name
 
 This fixture allows to check for an expected maximum number of DB queries.
 

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -463,7 +463,7 @@ If you use type annotations, you can annotate the fixture like this::
 ``django_assert_max_num_queries``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. py:function:: django_assert_max_num_queries(num, connection=None, info=None, using=None)
+.. py:function:: django_assert_max_num_queries(num, connection=None, info=None, *, using=None)
 
   :param num: expected maximum number of queries
   :param connection: optional database connection

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -468,7 +468,7 @@ If you use type annotations, you can annotate the fixture like this::
   :param num: expected maximum number of queries
   :param connection: optional database connection
   :param str info: optional info message to display on failure
-  :param str using: optional database connection name
+  :param str using: optional database alias
 
 This fixture allows to check for an expected maximum number of DB queries.
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -635,7 +635,7 @@ def _assert_num_queries(
         conn = connections[using]
     else:
         conn = default_conn
-    
+
     verbose = config.getoption("verbose") > 0
     with CaptureQueriesContext(conn) as context:
         yield context

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -622,8 +622,8 @@ def _assert_num_queries(
     *,
     using: str | None = None,
 ) -> Generator[django.test.utils.CaptureQueriesContext, None, None]:
-    from django.db import connections
     from django.db import connection as default_conn
+    from django.db import connections
     from django.test.utils import CaptureQueriesContext
 
     if connection and using:

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -607,6 +607,7 @@ class DjangoAssertNumQueries(Protocol):
         num: int,
         connection: Any | None = ...,
         info: str | None = ...,
+        *,
         using: str | None = ...,
     ) -> django.test.utils.CaptureQueriesContext:
         pass  # pragma: no cover

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -630,7 +630,7 @@ def _assert_num_queries(
 
     if using:
         if connection:
-            warings.warn("connection arg will be ignored")
+            warnings.warn("connection arg will be ignored")
         from django.db import connections
 
         conn = connections[using]

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -19,6 +19,7 @@ from typing import (
     Tuple,
     Union,
 )
+import warnings
 
 import pytest
 
@@ -628,6 +629,8 @@ def _assert_num_queries(
         conn = connection
 
     if using:
+        if connection:
+            warings.warn("connection arg will be ignored")
         from django.db import connections
 
         conn = connections[using]

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -620,6 +620,7 @@ def _assert_num_queries(
     exact: bool = True,
     connection: Any | None = None,
     info: str | None = None,
+    *,
     using: str | None = None,
 ) -> Generator[django.test.utils.CaptureQueriesContext, None, None]:
     from django.test.utils import CaptureQueriesContext

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -623,20 +623,19 @@ def _assert_num_queries(
     *,
     using: str | None = None,
 ) -> Generator[django.test.utils.CaptureQueriesContext, None, None]:
-    from django.test.utils import CaptureQueriesContext
+    from django.db import connections
+    from django.db import connection as default_conn
 
-    if connection is None:
-        from django.db import connection as conn
-    else:
+    if connection and using:
+        raise ValueError('The "connection" and "using" parameter cannot be used together')
+
+    if connection is not None:
         conn = connection
-
-    if using:
-        if connection:
-            warnings.warn("connection arg will be ignored", stacklevel=1)
-        from django.db import connections
-
+    elif using is not None:
         conn = connections[using]
-
+    else:
+        conn = default_conn
+    
     verbose = config.getoption("verbose") > 0
     with CaptureQueriesContext(conn) as context:
         yield context

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -606,6 +606,7 @@ class DjangoAssertNumQueries(Protocol):
         num: int,
         connection: Any | None = ...,
         info: str | None = ...,
+        using: str | None = ...,
     ) -> django.test.utils.CaptureQueriesContext:
         pass  # pragma: no cover
 
@@ -617,6 +618,7 @@ def _assert_num_queries(
     exact: bool = True,
     connection: Any | None = None,
     info: str | None = None,
+    using: str | None = None,
 ) -> Generator[django.test.utils.CaptureQueriesContext, None, None]:
     from django.test.utils import CaptureQueriesContext
 
@@ -624,6 +626,10 @@ def _assert_num_queries(
         from django.db import connection as conn
     else:
         conn = connection
+
+    if using:
+        from django.db import connections
+        conn = connections[using]
 
     verbose = config.getoption("verbose") > 0
     with CaptureQueriesContext(conn) as context:

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -622,9 +622,8 @@ def _assert_num_queries(
     *,
     using: str | None = None,
 ) -> Generator[django.test.utils.CaptureQueriesContext, None, None]:
+    from django.db import connection as default_conn, connections
     from django.test.utils import CaptureQueriesContext
-    from django.db import connection as default_conn
-    from django.db import connections
 
     if connection and using:
         raise ValueError('The "connection" and "using" parameter cannot be used together')

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from contextlib import contextmanager
 from functools import partial
 from typing import (
@@ -19,7 +20,6 @@ from typing import (
     Tuple,
     Union,
 )
-import warnings
 
 import pytest
 
@@ -630,7 +630,7 @@ def _assert_num_queries(
 
     if using:
         if connection:
-            warnings.warn("connection arg will be ignored")
+            warnings.warn("connection arg will be ignored", stacklevel=1)
         from django.db import connections
 
         conn = connections[using]

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -622,9 +622,9 @@ def _assert_num_queries(
     *,
     using: str | None = None,
 ) -> Generator[django.test.utils.CaptureQueriesContext, None, None]:
+    from django.test.utils import CaptureQueriesContext
     from django.db import connection as default_conn
     from django.db import connections
-    from django.test.utils import CaptureQueriesContext
 
     if connection and using:
         raise ValueError('The "connection" and "using" parameter cannot be used together')

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -629,6 +629,7 @@ def _assert_num_queries(
 
     if using:
         from django.db import connections
+
         conn = connections[using]
 
     verbose = config.getoption("verbose") > 0

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from contextlib import contextmanager
 from functools import partial
 from typing import (
@@ -625,6 +624,7 @@ def _assert_num_queries(
 ) -> Generator[django.test.utils.CaptureQueriesContext, None, None]:
     from django.db import connections
     from django.db import connection as default_conn
+    from django.test.utils import CaptureQueriesContext
 
     if connection and using:
         raise ValueError('The "connection" and "using" parameter cannot be used together')

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -207,6 +207,21 @@ def test_django_assert_num_queries_db_connection(
 
 
 @pytest.mark.django_db
+def test_django_assert_num_queries_db_using(
+    django_assert_num_queries: DjangoAssertNumQueries,
+) -> None:
+    with django_assert_num_queries(1, using="default"):
+        Item.objects.create(name="foo")
+
+    with django_assert_num_queries(1, using=None):
+        Item.objects.create(name="foo")
+
+    with pytest.raises(AttributeError):
+        with django_assert_num_queries(1, using=False):
+            pass
+
+
+@pytest.mark.django_db
 def test_django_assert_num_queries_output_info(django_pytester: DjangoPytester) -> None:
     django_pytester.create_test_module(
         """

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -219,7 +219,7 @@ def test_django_assert_num_queries_db_using(
     with django_assert_num_queries(1, using="default", connection=connection):
         Item.objects.create(name="foo")
 
-    with pytest.warns(UserWarning, "connection argument is ignored"):
+    with pytest.raises(ValueError):
         with django_assert_num_queries(1, connection=connection, using="default"):
             Item.objects.create(name="foo")
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -216,10 +216,8 @@ def test_django_assert_num_queries_db_using(
     with django_assert_num_queries(1, using="default"):
         Item.objects.create(name="foo")
 
-    with django_assert_num_queries(1, using="default", connection=connection):
-        Item.objects.create(name="foo")
-
-    with pytest.raises(ValueError):
+    error_message = 'The "connection" and "using" parameter cannot be used together'
+    with pytest.raises(ValueError, match=error_message):
         with django_assert_num_queries(1, connection=connection, using="default"):
             Item.objects.create(name="foo")
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -217,10 +217,6 @@ def test_django_assert_num_queries_db_using(
     with django_assert_num_queries(1, using=None):
         Item.objects.create(name="foo")
 
-    with pytest.raises(TypeError):
-        with django_assert_num_queries(1, using=True):
-            pass
-
     with pytest.raises(ConnectionDoesNotExist):
         with django_assert_num_queries(1, using="bad_db_name"):
             pass

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -15,6 +15,7 @@ from django.conf import settings as real_settings
 from django.core import mail
 from django.db import connection, transaction
 from django.test import AsyncClient, AsyncRequestFactory, Client, RequestFactory
+from django.utils.connection import ConnectionDoesNotExist
 from django.utils.encoding import force_str
 
 from .helpers import DjangoPytester
@@ -220,7 +221,7 @@ def test_django_assert_num_queries_db_using(
         with django_assert_num_queries(1, using=True):
             pass
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ConnectionDoesNotExist):
         with django_assert_num_queries(1, using="bad_db_name"):
             pass
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -211,7 +211,12 @@ def test_django_assert_num_queries_db_connection(
 def test_django_assert_num_queries_db_using(
     django_assert_num_queries: DjangoAssertNumQueries,
 ) -> None:
+    from django.db import connection
+
     with django_assert_num_queries(1, using="default"):
+        Item.objects.create(name="foo")
+
+    with django_assert_num_queries(1, using="default", connection=connection):
         Item.objects.create(name="foo")
 
     with django_assert_num_queries(1, using=None):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -199,6 +199,10 @@ def test_django_assert_num_queries_db_connection(
     with django_assert_num_queries(1, connection=connection):
         Item.objects.create(name="foo")
 
+    with pytest.warns(UserWarning, "connection argument is ignored"):
+        with django_assert_num_queries(1, connection=connection):
+            Item.objects.create(name="foo")
+
     with django_assert_num_queries(1, connection=None):
         Item.objects.create(name="foo")
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -217,7 +217,7 @@ def test_django_assert_num_queries_db_using(
         Item.objects.create(name="foo")
 
     with pytest.raises(AttributeError):
-        with django_assert_num_queries(1, using=False):
+        with django_assert_num_queries(1, using=True):
             pass
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -216,8 +216,12 @@ def test_django_assert_num_queries_db_using(
     with django_assert_num_queries(1, using=None):
         Item.objects.create(name="foo")
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         with django_assert_num_queries(1, using=True):
+            pass
+
+    with pytest.raises(TypeError):
+        with django_assert_num_queries(1, using="bad_db_name"):
             pass
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -199,10 +199,6 @@ def test_django_assert_num_queries_db_connection(
     with django_assert_num_queries(1, connection=connection):
         Item.objects.create(name="foo")
 
-    with pytest.warns(UserWarning, "connection argument is ignored"):
-        with django_assert_num_queries(1, connection=connection):
-            Item.objects.create(name="foo")
-
     with django_assert_num_queries(1, connection=None):
         Item.objects.create(name="foo")
 
@@ -222,6 +218,10 @@ def test_django_assert_num_queries_db_using(
 
     with django_assert_num_queries(1, using="default", connection=connection):
         Item.objects.create(name="foo")
+
+    with pytest.warns(UserWarning, "connection argument is ignored"):
+        with django_assert_num_queries(1, connection=connection, using="default"):
+            Item.objects.create(name="foo")
 
     with django_assert_num_queries(1, using=None):
         Item.objects.create(name="foo")


### PR DESCRIPTION
* Depend on https://github.com/pytest-dev/pytest-django/pull/1171

Adds quality of life to replace

```python
from django.db import connections

def test_test():
    with django_assert_num_queries(1, connection=connections["log"]):
        Model.objects.get()
```

with

```python
def test_test():
    with django_assert_num_queries(1, using="log"):
        Model.objects.get()
```

_I have multiple DBs and this is driving me nuts..._