### PR TITLE
Fixes CI issue with main + py11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,17 +103,21 @@ jobs:
           python: '3.9'
           allow_failure: false
 
+        - name: py312-djmain-sqlite-coverage
+          python: '3.12'
+          allow_failure: true
+
         - name: py312-dj51-sqlite-xdist-coverage
           python: '3.12'
+          allow_failure: false
+
+        - name: py311-dj42-sqlite-xdist-coverage
+          python: '3.11'
           allow_failure: false
 
         - name: py38-dj42-sqlite-xdist-coverage
           python: '3.8'
           allow_failure: false
-
-        - name: py311-djmain-sqlite-coverage
-          python: '3.11'
-          allow_failure: true
 
         - name: py311-dj42-mysql_myisam-coverage
           python: '3.11'


### PR DESCRIPTION
As mentioned in the title, [django does not support py11 in the latest (main) branch](https://github.com/django/django/blob/main/pyproject.toml#L8) and its causing that particular test to fail.

Let me know if you want me to move things around.

_This came about because i wanted to do https://github.com/pytest-dev/pytest-django/pull/1170 and ran into this issue there._