### PR TITLE
Developer QOL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-main-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PYTEST_ADDOPTS: "--color=yes"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ on:
 concurrency:
   group: ci-main-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-  # Test cancel
 
 env:
   PYTEST_ADDOPTS: "--color=yes"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
 concurrency:
   group: ci-main-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Test cancel
 
 env:
   PYTEST_ADDOPTS: "--color=yes"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ci-main-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   PYTEST_ADDOPTS: "--color=yes"

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     ruff==0.9.5
     mypy==1.15.0
 commands =
-    ruff check {posargs:pytest_django pytest_django_test tests}
+    ruff check --diff {posargs:pytest_django pytest_django_test tests}
     ruff format --quiet --diff {posargs:pytest_django pytest_django_test tests}
     mypy {posargs:pytest_django pytest_django_test tests}
 


### PR DESCRIPTION
* This update addresses two common pain points when developing on GitHub.com's browser editor:
  1. Delayed CI Testing: Small changes often accumulate, causing the CI to wait for all previous commits before testing your current commit. This delay can be inefficient. Suggestion: Cancel previous CI runs when pushing new commits to speed up the feedback loop.
  2. Lack of Fix Suggestions for `ruff` Issues: When ruff flags an issue, it highlights the problematic code block but doesn't suggest how to fix it. By adding the `--diff` option, you can see the differences and get guidance on correcting the issue.

All this came about while working on https://github.com/pytest-dev/pytest-django/pull/1170