### PR TITLE
Add support for Django 5.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,10 @@ jobs:
           python: '3.13'
           allow_failure: false
 
+        - name: py313-dj52-postgres-xdist-coverage
+          python: '3.13'
+          allow_failure: false
+
         - name: py313-dj51-postgres-xdist-coverage
           python: '3.13'
           allow_failure: false
@@ -85,6 +89,10 @@ jobs:
 
         - name: py311-dj42-postgres-xdist-coverage
           python: '3.11'
+          allow_failure: false
+
+        - name: py310-dj52-postgres-xdist-coverage
+          python: '3.10'
           allow_failure: false
 
         - name: py310-dj51-postgres-xdist-coverage
@@ -108,6 +116,10 @@ jobs:
           allow_failure: false
 
         - name: py313-djmain-sqlite-coverage
+          python: '3.13'
+          allow_failure: true
+
+        - name: py313-dj52-sqlite-coverage
           python: '3.13'
           allow_failure: true
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ pytest-django allows you to test your Django project/applications with the
   <https://pytest-django.readthedocs.io/en/latest/contributing.html>`_
 * Version compatibility:
 
-  * Django: 4.2, 5.0, 5.1 and latest main branch (compatible at the time
+  * Django: 4.2, 5.0, 5.1, 5.2 and latest main branch (compatible at the time
     of each release)
   * Python: CPython>=3.8 or PyPy 3
   * pytest: >=7.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+v4.11.0 (Not released yet)
+--------------------------
+
+Compatibility
+^^^^^^^^^^^^^
+
+* Added official support for Django 5.2.
+
+
 v4.10.0 (2025-02-10)
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py313-dj{main,51}-postgres
-    py312-dj{main,51,50,42}-postgres
-    py311-dj{main,51,50,42}-postgres
-    py310-dj{main,51,50,42}-postgres
+    py313-dj{main,52,51}-postgres
+    py312-dj{main,52,51,50,42}-postgres
+    py311-dj{main,52,51,50,42}-postgres
+    py310-dj{main,52,51,50,42}-postgres
     py39-dj42-postgres
     py38-dj42-postgres
     linting
@@ -12,6 +12,7 @@ envlist =
 extras = testing
 deps =
     djmain: https://github.com/django/django/archive/main.tar.gz
+    dj52: Django>=5.2a1,<6.0
     dj51: Django>=5.1,<5.2
     dj50: Django>=5.0,<5.1
     dj42: Django>=4.2,<4.3


### PR DESCRIPTION
It’s in beta since Feb 19: https://www.djangoproject.com/weblog/2025/feb/19/django-52-beta-1-released/ . Final release expected April 2nd.

Since we're already testing the main branch, few changes are needed.

I copied what to change from #1143.

I’m a bit confused about what entries we include on the testing matrix, so I just added a few that I thought would make sense.