### PR TITLE
fixtures: fixup a regression in previous release for TestCase multi-db support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v4.11.1 (TBD)
+-------------
+
+Bugfixes
+^^^^^^^^
+
+* Fixed a regression in v4.11.0 for Django ``TestCase`` tests using the ``databases`` class variable (`#1188 <https://github.com/pytest-dev/pytest-django/issues/1188>`__).
+
 v4.11.0 (2025-04-01)
 --------------------
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -129,8 +129,8 @@ def _get_databases_for_test(test: pytest.Item) -> tuple[Iterable[str], bool]:
 
     test_cls = getattr(test, "cls", None)
     if test_cls and issubclass(test_cls, TransactionTestCase):
-        serialized_rollback = getattr(test, "serialized_rollback", False)
-        databases = getattr(test, "databases", None)
+        serialized_rollback = getattr(test_cls, "serialized_rollback", False)
+        databases = getattr(test_cls, "databases", None)
     else:
         fixtures = getattr(test, "fixturenames", ())
         marker_db = test.get_closest_marker("django_db")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -432,6 +432,28 @@ def test_unittest_interaction(django_pytester: DjangoPytester) -> None:
     )
 
 
+def test_django_testcase_multi_db(django_pytester: DjangoPytester) -> None:
+    """Test that Django TestCase multi-db support works."""
+
+    django_pytester.create_test_module(
+        """
+        import pytest
+        from django.test import TestCase
+        from .app.models import Item, SecondItem
+
+        class TestCase(TestCase):
+            databases = ["default", "second"]
+
+            def test_db_access(self):
+                Item.objects.count() == 0
+                SecondItem.objects.count() == 0
+        """
+    )
+
+    result = django_pytester.runpytest_subprocess("-v", "--reuse-db")
+    result.assert_outcomes(passed=1)
+
+
 class Test_database_blocking:
     def test_db_access_in_conftest(self, django_pytester: DjangoPytester) -> None:
         """Make sure database access in conftest module is prohibited."""


### PR DESCRIPTION
Accidentally used the wrong variable.

Fixes #1188.