### PR TITLE
Remove experimental label from multi-db support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v4.12.0 (Not released yet)
+--------------------------
+
+Improvements
+^^^^^^^^^^^^
+
+* The :ref:`multiple databases <multi-db>` support added in v4.3.0 is no longer considered experimental.
+
 v4.11.1 (2025-04-03)
 --------------------
 

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -37,8 +37,8 @@ documentation <pytest:scoped-marking>` for detail::
            assert me.is_superuser
 
 
-By default ``pytest-django`` will set up the Django databases the
-first time a test needs them.  Once setup, the database is cached to be
+By default ``pytest-django`` will set up Django databases the
+first time a test needs them.  Once setup, a database is cached to be
 used for all subsequent tests and rolls back transactions, to isolate
 tests from each other.  This is the same way the standard Django
 :class:`~django.test.TestCase` uses the database.  However
@@ -67,21 +67,15 @@ Tests requiring multiple databases
 
 .. versionadded:: 4.3
 
-.. caution::
-
-    This support is **experimental** and is subject to change without
-    deprecation. We are still figuring out the best way to expose this
-    functionality. If you are using this successfully or unsuccessfully,
-    `let us know <https://github.com/pytest-dev/pytest-django/issues/924>`_!
-
-``pytest-django`` has experimental support for multi-database configurations.
-Currently ``pytest-django`` does not specifically support Django's
-multi-database support, using the ``databases`` argument to the
-:func:`django_db <pytest.mark.django_db>` mark::
+``pytest-django`` has support for multi-database configurations using the
+``databases`` argument to the :func:`django_db <pytest.mark.django_db>` mark::
 
    @pytest.mark.django_db(databases=['default', 'other'])
    def test_spam():
        assert MyModel.objects.using('other').count() == 0
+
+If you don't specify ``databases``, only the default database is requested.
+To request all databases, you may use the shortcut ``'__all__'``.
 
 For details see :attr:`django.test.TransactionTestCase.databases` and
 :attr:`django.test.TestCase.databases`.

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -59,16 +59,10 @@ dynamically in a hook or fixture.
 
   :type databases: Iterable[str] | str | None
   :param databases:
-    .. caution::
-
-      This argument is **experimental** and is subject to change without
-      deprecation. We are still figuring out the best way to expose this
-      functionality. If you are using this successfully or unsuccessfully,
-      `let us know <https://github.com/pytest-dev/pytest-django/issues/924>`_!
 
     The ``databases`` argument defines which databases in a multi-database
     configuration will be set up and may be used by the test.  Defaults to
-    only the ``default`` database.  The special value ``"__all__"`` may be use
+    only the ``default`` database.  The special value ``"__all__"`` may be used
     to specify all configured databases.
     For details see :attr:`django.test.TransactionTestCase.databases` and
     :attr:`django.test.TestCase.databases`.


### PR DESCRIPTION
It works, is in use, and there are no known issues, so let's make it stable.