### PR TITLE
Fix the order of the test cases that use the live_server fixture

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -463,7 +463,9 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 uses_db = False
                 transactional = False
             fixtures = getattr(test, "fixturenames", [])
-            transactional = transactional or "transactional_db" in fixtures
+            transactional = transactional or (
+                "transactional_db" in fixtures or "live_server" in fixtures
+            )
             uses_db = uses_db or "db" in fixtures
 
         if transactional:

--- a/tests/test_db_setup.py
+++ b/tests/test_db_setup.py
@@ -54,6 +54,9 @@ def test_db_order(django_pytester: DjangoPytester) -> None:
         def test_run_second_fixture(transactional_db):
             pass
 
+        def test_run_second_live_server_fixture(live_server):
+            pass
+
         def test_run_second_reset_sequences_fixture(django_db_reset_sequences):
             pass
 
@@ -107,6 +110,7 @@ def test_db_order(django_pytester: DjangoPytester) -> None:
             "*test_run_first_serialized_rollback_decorator*",
             "*test_run_second_decorator*",
             "*test_run_second_fixture*",
+            "*test_run_second_live_server_fixture*",
             "*test_run_second_reset_sequences_fixture*",
             "*test_run_second_transaction_test_case*",
             "*test_run_second_fixture_class*",


### PR DESCRIPTION
The `live_server` fixture requires `transactional_db`, but it does so at runtime, i.e. after the `pytest_collection_modifyitems()` hook is called, so it was originally sent to the last test group.