### PR TITLE
Add type definition for assertNotInHTML

### DIFF
--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -160,6 +160,13 @@ if TYPE_CHECKING:
         msg_prefix: str = ...,
     ) -> None: ...
 
+    # Added in Django 5.1.
+    def assertNotInHTML(
+        needle: str,
+        haystack: str,
+        msg_prefix: str = ...,
+    ) -> None: ...
+
     def assertJSONEqual(
         raw: str,
         expected_data: Any,


### PR DESCRIPTION
This will help with editor autocomplete and so it gets recognised as a valid import.