### PR TITLE
pyproject.toml: switch from extras to dependency groups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox==4.11.1
+          pip install tox==4.26.0
 
       - name: Run tox
         run: tox -e ${{ matrix.name }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 dependencies = [
     "pytest>=7.0.0",
 ]
-[project.optional-dependencies]
+[dependency-groups]
 docs = [
     "sphinx",
     "sphinx_rtd_theme",
@@ -48,6 +48,23 @@ docs = [
 testing = [
     "Django",
     "django-configurations>=2.0",
+]
+coverage = [
+    "coverage[toml]",
+    "coverage-enable-subprocess",
+]
+postgres = [
+    "psycopg[binary]",
+]
+mysql = [
+    "mysqlclient==2.1.0",
+]
+xdist = [
+    "pytest-xdist",
+]
+linting = [
+    "ruff==0.9.5",
+    "mypy==1.15.0",
 ]
 [project.urls]
 Documentation = "https://pytest-django.readthedocs.io/"

--- a/tox.ini
+++ b/tox.ini
@@ -8,22 +8,19 @@ envlist =
     linting
 
 [testenv]
-extras = testing
+dependency_groups =
+    testing
+    coverage: coverage
+    mysql: mysql
+    postgres: postgres
+    xdist: xdist
 deps =
     djmain: https://github.com/django/django/archive/main.tar.gz
     dj52: Django>=5.2a1,<6.0
     dj51: Django>=5.1,<5.2
     dj50: Django>=5.0,<5.1
     dj42: Django>=4.2,<4.3
-
-    mysql: mysqlclient==2.1.0
-
-    postgres: psycopg[binary]
-    coverage: coverage[toml]
-    coverage: coverage-enable-subprocess
-
     pytestmin: pytest>=7.0,<7.1
-    xdist: pytest-xdist>=1.15
 
 setenv =
     mysql: DJANGO_SETTINGS_MODULE=pytest_django_test.settings_mysql
@@ -46,26 +43,21 @@ commands =
     coverage: coverage xml
 
 [testenv:linting]
-extras =
-deps =
-    ruff==0.9.5
-    mypy==1.15.0
+dependency_groups = linting
 commands =
     ruff check --diff {posargs:pytest_django pytest_django_test tests}
     ruff format --quiet --diff {posargs:pytest_django pytest_django_test tests}
     mypy {posargs:pytest_django pytest_django_test tests}
 
 [testenv:doc8]
-extras =
 basepython = python3
 skip_install = true
+dependency_groups = docs
 deps =
-    sphinx
     doc8
 commands =
     doc8 docs/
 
 [testenv:docs]
-deps =
-extras = docs
+dependency_groups = docs
 commands = sphinx-build -n -W -b html -d docs/_build/doctrees docs docs/_build/html


### PR DESCRIPTION
See https://packaging.python.org/en/latest/specifications/dependency-groups/ More suitable for internal stuff than extras which are exposed externally.

Also moves all development dependency declarations from tox.ini to be in a single place, pyproject.toml.