### PR TITLE
Adds uv to tox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install tox==4.26.0
+          python -m pip install uv
+          uv tool install tox==4.26.0 --with tox-uv
 
       - name: Run tox
         run: tox


### PR DESCRIPTION
For the most part, the "Install dependencies" step, sees a decrease of 2-3s for each job
[Main](https://github.com/pytest-dev/pytest-django/actions/runs/15476151028)
[This PR](https://github.com/pytest-dev/pytest-django/actions/runs/15478405158?pr=1216)