### PR TITLE
Fix local linter issues

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -3,7 +3,9 @@
     "pytest_django/fixtures.py",
     ".tox/*",
     ".ruff_cache/*",
-    "pytest_django.egg-info/*"
+    "pytest_django.egg-info/*",
+    "__pycache__/*",
+    "zizmor.sarif"
   ],
   "Disable": {
     "MaxLineLength": true


### PR DESCRIPTION
After introducing `ec` yesterday, I realized it causes issues when you run it multiple times locally.

Related to https://github.com/pytest-dev/pytest-django/pull/1225, https://github.com/pytest-dev/pytest-django/pull/1226