### PR TITLE
ruff: Fixes ruff linter to warn about all issues

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ commands =
 [testenv:linting]
 dependency_groups = linting
 commands =
-    ruff check --diff {posargs:pytest_django pytest_django_test tests}
+    ruff check {posargs:pytest_django pytest_django_test tests}
     ruff format --quiet --diff {posargs:pytest_django pytest_django_test tests}
     mypy {posargs:pytest_django pytest_django_test tests}
     ec .


### PR DESCRIPTION
This was my bad, introduced here https://github.com/pytest-dev/pytest-django/pull/1174 -- `--diff` is perfect for local dev use, not great for CI as it hides some errors that ruff doesn't know how to fix, but are still errors.