### PR TITLE
Fix type hints of assert functions

### DIFF
--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -25,7 +25,7 @@ else:
     test_case = TestCase("run")
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Collection, Iterable, Iterator, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Sequence
     from contextlib import AbstractContextManager
     from typing import Any, overload
 

--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -25,7 +25,7 @@ else:
     test_case = TestCase("run")
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Collection, Iterator, Sequence
+    from collections.abc import Callable, Collection, Iterable, Iterator, Sequence
     from contextlib import AbstractContextManager
     from typing import Any, overload
 
@@ -130,14 +130,14 @@ if TYPE_CHECKING:
         expected_message: str,
         *args: Any,
         **kwargs: Any,
-    ) -> None: ...
+    ) -> Any: ...
 
     def assertWarnsMessage(
         expected_warning: Warning,
         expected_message: str,
         *args: Any,
         **kwargs: Any,
-    ) -> None: ...
+    ) -> Any: ...
 
     def assertFieldOutput(
         fieldclass: type[forms.Field],
@@ -146,7 +146,7 @@ if TYPE_CHECKING:
         field_args: Any = ...,
         field_kwargs: Any = ...,
         empty_value: str = ...,
-    ) -> None: ...
+    ) -> Any: ...
 
     def assertHTMLEqual(
         html1: str,
@@ -201,7 +201,7 @@ if TYPE_CHECKING:
     # Removed in Django 5.1: use assertQuerySetEqual.
     def assertQuerysetEqual(
         qs: Iterator[Any] | list[Model] | QuerySet | RawQuerySet,
-        values: Collection[Any],
+        values: Iterable[Any],
         transform: Callable[[Model], Any] | type[str] | None = ...,
         ordered: bool = ...,
         msg: str | None = ...,
@@ -209,7 +209,7 @@ if TYPE_CHECKING:
 
     def assertQuerySetEqual(
         qs: Iterator[Any] | list[Model] | QuerySet | RawQuerySet,
-        values: Collection[Any],
+        values: Iterable[Any],
         transform: Callable[[Model], Any] | type[str] | None = ...,
         ordered: bool = ...,
         msg: str | None = ...,


### PR DESCRIPTION
Updated type hints in assert functions to use Iterable instead of Collection. And have assertRaisesMessage return something to use as a context manager.

This is in line with `django-stubs`: https://github.com/typeddjango/django-stubs/blob/master/django-stubs/test/testcases.pyi

Version 4.12.0 raises the following errors with `mypy`:

```console
error: "assertRaisesMessage" does not return a value (it only ever returns None)  [func-returns-value]

error: Argument 2 to "assertQuerySetEqual" has incompatible type "QuerySet[Foo, Foo]"; expected "Collection[Any]"  [arg-type]
note: "QuerySet" is missing following "Collection" protocol member:
note:     __contains__
```