### PR TITLE
Fix `--help`/`--version` when conftest imports models

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Bugfixes
 ^^^^^^^^
 
 * Fixed type hints of assert methods to match actual signature (`PR #1271 <https://github.com/pytest-dev/pytest-django/pull/1271>`__)
+* Fix Pytest `--help`/`--version` options when a `conftest.py` file imports Django models (`PR #1275 <https://github.com/pytest-dev/pytest-django/pull/1275>`__).
 
 v4.12.0 (2026-02-14)
 --------------------

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -307,8 +307,7 @@ def pytest_load_initial_conftests(
 
     options = parser.parse_known_args(args)
 
-    if options.version or options.help:
-        return
+    is_help_or_version = bool(options.version or options.help)
 
     django_find_project = _get_boolean_value(
         early_config.getini("django_find_project"), "django_find_project"
@@ -363,11 +362,21 @@ def pytest_load_initial_conftests(
         from django.conf import settings as dj_settings
 
         with _handle_import_error(_django_project_scan_outcome):
-            dj_settings.DATABASES  # noqa: B018
+            try:
+                dj_settings.DATABASES  # noqa: B018
+            except ImportError:
+                # Don't allow invalid settings to prevent printing these
+                if not is_help_or_version:
+                    raise
 
     early_config.stash[blocking_manager_key] = DjangoDbBlocker(_ispytest=True)
 
-    _setup_django(early_config)
+    try:
+        _setup_django(early_config)
+    except Exception:
+        # Don't allow invalid settings to prevent printing these
+        if not is_help_or_version:
+            raise
 
 
 @pytest.hookimpl(trylast=True)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,5 +1,7 @@
 from textwrap import dedent
 
+import pytest
+
 from .helpers import DjangoPytester
 
 
@@ -60,3 +62,38 @@ def test_django_setup_order_and_uniqueness(django_pytester: DjangoPytester) -> N
         ]
     )
     assert result.ret == 0
+
+
+@pytest.mark.parametrize("flag", ["--help", "--version"])
+def test_django_setup_for_help_and_version_with_model_import(
+    django_pytester: DjangoPytester,
+    flag: str,
+) -> None:
+    """Django should be set up before conftest files are loaded, even with
+    --help/--version, so that top-level model imports in conftest files
+    don't fail with AppRegistryNotReady.
+
+    Regression test for https://github.com/pytest-dev/pytest-django/issues/1152
+    """
+    django_pytester.makeconftest(
+        """
+        from tpkg.app.models import Item
+    """
+    )
+
+    django_pytester.makepyfile(
+        """
+        def test_placeholder():
+            pass
+    """
+    )
+
+    args = [flag]
+    if flag == "--version":
+        # pytest requires -V passed twice to actually print version info
+        args.append(flag)
+
+    result = django_pytester.runpytest_subprocess(*args)
+    assert result.ret == 0
+    result.stderr.no_fnmatch_line("*AppRegistryNotReady*")
+    result.stderr.no_fnmatch_line("*could not load initial conftests*")


### PR DESCRIPTION
Previously, `pytest_load_initial_conftests` returned early when `--help` or `--version` was passed (added by #238), skipping `django.setup()` entirely. This caused conftest files with top-level Django model imports to fail with `AppRegistryNotReady`.

Instead of returning early, continue with normal Django initialization, allowing `--help`/`--version` to return properly when everything is valid.

If Django is somehow invalid (e.g. incorrect `DJANGO_SETTINGS_MODULE`), add a guard to still return gracefully if `--help`/`--version` is requested. Running real tests would still fail, but these basic informational arguments shouldn't be blocked.

Fixes #1152