### PR TITLE
Complete type stubs for `assertTemplateUsed` / `assertTemplateNotUsed`

### DIFF
--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -112,18 +112,69 @@ if TYPE_CHECKING:
         msg_prefix: str = ...,
     ) -> None: ...
 
+    # with assertTemplateUsed("template.html"): ...  # noqa: ERA001
+    @overload
+    def assertTemplateUsed(
+        response: str,
+        template_name: None = ...,
+        msg_prefix: str = ...,
+        count: int | None = ...,
+    ) -> AbstractContextManager[None]: ...
+
+    # with assertTemplateUsed(template_name="template.html"): ...  # noqa: ERA001
+    @overload
+    def assertTemplateUsed(
+        response: None = ...,
+        template_name: str | None = ...,
+        msg_prefix: str = ...,
+        count: int | None = ...,
+    ) -> AbstractContextManager[None]: ...
+
+    # assertTemplateUsed(response, "template.html")  # noqa: ERA001
+    @overload
+    def assertTemplateUsed(
+        response: HttpResponseBase,
+        template_name: str | None = ...,
+        msg_prefix: str = ...,
+        count: int | None = ...,
+    ) -> None: ...
+
     def assertTemplateUsed(
         response: HttpResponseBase | str | None = ...,
         template_name: str | None = ...,
         msg_prefix: str = ...,
         count: int | None = ...,
+    ): ...
+
+    # with assertTemplateNotUsed("template.html"): ...  # noqa: ERA001
+    @overload
+    def assertTemplateNotUsed(
+        response: str,
+        template_name: None = ...,
+        msg_prefix: str = ...,
+    ) -> AbstractContextManager[None]: ...
+
+    # with assertTemplateNotUsed(template_name="template.html"): ...  # noqa: ERA001
+    @overload
+    def assertTemplateNotUsed(
+        response: None = ...,
+        template_name: str | None = ...,
+        msg_prefix: str = ...,
+    ) -> AbstractContextManager[None]: ...
+
+    # assertTemplateNotUsed(response, "template.html")  # noqa: ERA001
+    @overload
+    def assertTemplateNotUsed(
+        response: HttpResponseBase,
+        template_name: str | None = ...,
+        msg_prefix: str = ...,
     ) -> None: ...
 
     def assertTemplateNotUsed(
         response: HttpResponseBase | str | None = ...,
         template_name: str | None = ...,
         msg_prefix: str = ...,
-    ) -> None: ...
+    ): ...
 
     def assertRaisesMessage(
         expected_exception: type[Exception],


### PR DESCRIPTION
mypy 1.20 (python/mypy#20350) changes how it types the return value of functions that return `None`: previously it used `Any` (suppressing downstream errors), now it propagates the actual `None` type. This means the existing `-> None` annotation on `assertTemplateUsed` / `assertTemplateNotUsed` causes type errors when these functions are used as context managers.

This adds `@overload` signatures to distinguish the two calling conventions, matching the pattern already used by `assertNumQueries` in this file:

* `response` is `HttpResponseBase`: direct assertion, returns `None`
* `response` is a `str` (shorthand for `template_name`): returns context manager
* `response` is `None` (`template_name` passed by keyword): returns context manager