### PR TITLE
Handle Django 6.2 `ImproperlyConfigured` for an invalid DJANGO_SETTINGS_MODULE

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Bugfixes
 ^^^^^^^^
 
 * Fixed type hints of assert methods to match actual signature (`PR #1271 <https://github.com/pytest-dev/pytest-django/pull/1271>`__)
+* Handled Django 6.2's ``ImproperlyConfigured`` (in addition to ``ImportError``) when the configured ``DJANGO_SETTINGS_MODULE`` cannot be imported, so pytest-django still shows its guidance message.
 
 v4.12.0 (2026-02-14)
 --------------------

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -181,9 +181,14 @@ PROJECT_SCAN_DISABLED = (
 
 @contextlib.contextmanager
 def _handle_import_error(extra_message: str) -> Generator[None, None, None]:
+    # An invalid DJANGO_SETTINGS_MODULE raises ImportError on Django < 6.2, but
+    # Django >= 6.2 wraps it in ImproperlyConfigured. Handle both so the
+    # guidance message is shown regardless of the Django version.
+    from django.core.exceptions import ImproperlyConfigured
+
     try:
         yield
-    except ImportError as e:
+    except (ImportError, ImproperlyConfigured) as e:
         django_msg = (e.args[0] + "\n\n") if e.args else ""
         msg = django_msg + extra_message
         raise ImportError(msg) from None


### PR DESCRIPTION
On Django 6.2 (the `djmain` CI jobs), an invalid `DJANGO_SETTINGS_MODULE` raises `django.core.exceptions.ImproperlyConfigured` instead of `ImportError`. `_handle_import_error` only caught `ImportError`, so on 6.2 the settings-import failure escaped it — pytest-django's guidance message ("pytest-django found a Django project…" / "did not search…") was dropped, and the error type changed.

This caught three tests that assert on that output: `test_ds_non_existent`, `test_django_project_found_invalid_settings`, and `test_django_project_scan_disabled_invalid_settings`.

Fix: catch `ImproperlyConfigured` alongside `ImportError` and re-raise as `ImportError` (as before), so the guidance is shown and behavior is consistent across Django versions. No test assertions changed. Verified against Django 4.2–6.2.