### PR TITLE
Don't run `_pre_setup()` twice for transactional tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Bugfixes
 
 * Fixed type hints of assert methods to match actual signature (`PR #1271 <https://github.com/pytest-dev/pytest-django/pull/1271>`__)
 * Handled Django 6.2's ``ImproperlyConfigured`` (in addition to ``ImportError``) when the configured ``DJANGO_SETTINGS_MODULE`` cannot be imported, so pytest-django still shows its guidance message.
+* Fixed ``django_db(transaction=True)`` tests being set up twice, which repeated the ``serialized_rollback`` restore and the ``fixtures`` load, and sent ``setting_changed`` and ``post_migrate`` twice when ``available_apps`` is set.
 
 v4.12.0 (2026-02-14)
 --------------------

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -289,7 +289,10 @@ def _django_db_helper(
         PytestDjangoTestCase.setUpClass()
 
         test_case = PytestDjangoTestCase(methodName="__init__")
-        test_case._pre_setup()
+        if not PytestDjangoTestCase._pre_setup_ran_eagerly:
+            # For a TransactionTestCase, setUpClass() has already run _pre_setup() and set
+            # this flag to say so.
+            test_case._pre_setup()
 
         yield
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -463,6 +463,46 @@ def test_django_testcase_multi_db(django_pytester: DjangoPytester) -> None:
     result.assert_outcomes(passed=1)
 
 
+def test_pre_setup_runs_once_per_test(django_pytester: DjangoPytester) -> None:
+    """A transactional test is set up twice, a plain one once.
+
+    Django's TransactionTestCase.setUpClass() runs _pre_setup() eagerly, and we then run
+    it again ourselves.
+    """
+
+    django_pytester.create_test_module(
+        """
+        import sys
+
+        import pytest
+        from django.test import TransactionTestCase
+
+        # Name of the function that called _pre_setup(), appended once per call and
+        # never reset, so the list below is the setup history of the whole module.
+        callers = []
+        original_pre_setup = TransactionTestCase._pre_setup.__func__
+
+        @classmethod
+        def recording_pre_setup(cls):
+            callers.append(sys._getframe(1).f_code.co_name)
+            original_pre_setup(cls)
+
+        TransactionTestCase._pre_setup = recording_pre_setup
+
+        @pytest.mark.django_db
+        def test_plain_db():
+            assert callers == ["_django_db_helper"]
+
+        @pytest.mark.django_db(transaction=True)
+        def test_transactional_db():
+            assert callers == ["_django_db_helper", "setUpClass", "_django_db_helper"]
+        """
+    )
+
+    result = django_pytester.runpytest_subprocess("-v", "--reuse-db")
+    result.assert_outcomes(passed=2)
+
+
 class Test_database_blocking:
     def test_db_access_in_conftest(self, django_pytester: DjangoPytester) -> None:
         """Make sure database access in conftest module is prohibited."""

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -464,10 +464,10 @@ def test_django_testcase_multi_db(django_pytester: DjangoPytester) -> None:
 
 
 def test_pre_setup_runs_once_per_test(django_pytester: DjangoPytester) -> None:
-    """A transactional test is set up twice, a plain one once.
+    """Each test is set up by exactly one _pre_setup() call.
 
-    Django's TransactionTestCase.setUpClass() runs _pre_setup() eagerly, and we then run
-    it again ourselves.
+    A plain test is set up by us, a transactional one by Django's
+    TransactionTestCase.setUpClass(), which runs _pre_setup() eagerly.
     """
 
     django_pytester.create_test_module(
@@ -495,7 +495,7 @@ def test_pre_setup_runs_once_per_test(django_pytester: DjangoPytester) -> None:
 
         @pytest.mark.django_db(transaction=True)
         def test_transactional_db():
-            assert callers == ["_django_db_helper", "setUpClass", "_django_db_helper"]
+            assert callers == ["_django_db_helper", "setUpClass"]
         """
     )
 


### PR DESCRIPTION
Since Django 5.2, `TransactionTestCase.setUpClass()` calls `cls._pre_setup()` eagerly and sets `_pre_setup_ran_eagerly` so that whoever drives the test case can skip its own call, the way `unittest.TestCase.run()` does. `_django_db_helper()` calls `setUpClass()` and then `test_case._pre_setup()` unconditionally, so every `django_db(transaction=True)` test has its fixtures set up twice: the `serialized_rollback` restore, the `fixtures` load and the sequence reset all run again. On a suite of 121 transactional tests that was 567s against 445s, roughly 1s per test.

The first commit adds a test recording which frames call `_pre_setup()`. It passes on current `main` and asserts the duplicate: a plain `django_db` test records one call, a transactional one records `setUpClass` and then a second call from `_django_db_helper()`.

The second commit consumes `_pre_setup_ran_eagerly` in `_django_db_helper()` and flips that assertion to the single call. Verified against Django 5.2; the eager call is unchanged on 6.0 and main.
