### PR TITLE
Add missing type annotations for non_debugging_runtest

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -588,7 +588,7 @@ def _django_setup_unittest(
 
     original_runtest = TestCaseFunction.runtest
 
-    def non_debugging_runtest(self) -> None:  # noqa: ANN001
+    def non_debugging_runtest(self: TestCaseFunction) -> None:
         self._testcase(result=self)
 
     from django.test import SimpleTestCase


### PR DESCRIPTION
…n_debugging_runtest

This PR fixes missing type annotations identified during strict type checking:

- **`pytest_django/asserts.py`**: Added missing parameter (`func: Callable[..., Any] | None = ...`) and return type (`-> AbstractContextManager[None] | None`) annotations to the `assertNumQueries` overload implementation.
- **`pytest_django/plugin.py`**: Added explicit type annotation (`self: TestCaseFunction`) for `non_debugging_runtest` parameter and removed unnecessary `noqa: ANN001`.

All mypy strict checks pass cleanly.