### PR TITLE
Update mypy dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,10 @@ xdist = [
     "pytest-xdist",
 ]
 linting = [
-    "editorconfig-checker==3.2.1",
-    "mypy==1.17.1",
-    "ruff==0.12.8",
-    "zizmor==1.11.0",
+    "editorconfig-checker==3.8.0",
+    "mypy==2.3.0",
+    "ruff==0.16.1",
+    "zizmor==1.29.0",
 ]
 [project.urls]
 Documentation = "https://pytest-django.readthedocs.io/"

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -66,14 +66,14 @@ class TestDjangoTagsToPytestMarkers(SimpleTestCase):
     def gimme_my_markers(self, request: pytest.FixtureRequest) -> None:
         self.markers = {m.name for m in request.node.iter_markers()}
 
-    @tag("tag3", "tag4")  # type: ignore[misc]
+    @tag("tag3", "tag4")  # type: ignore[untyped-decorator]
     def test_1(self) -> None:
         assert self.markers == {"tag1", "tag2", "tag3", "tag4"}
 
     def test_2(self) -> None:
         assert self.markers == {"tag1", "tag2"}
 
-    @tag("tag5")  # type: ignore[misc]
+    @tag("tag5")  # type: ignore[untyped-decorator]
     def test_3(self) -> None:
         assert self.markers == {"tag1", "tag2", "tag5"}
 
@@ -87,7 +87,7 @@ class TestNonDjangoClassWithTags:
     def gimme_my_markers(self, request: pytest.FixtureRequest) -> None:
         self.markers = {m.name for m in request.node.iter_markers()}
 
-    @tag("tag2")  # type: ignore[misc]
+    @tag("tag2")  # type: ignore[untyped-decorator]
     def test_1(self) -> None:
         assert not self.markers
 


### PR DESCRIPTION
- Bump mypy version
- Change type ignore comments from 'misc' to 'untyped-decorator' for clarity in test cases.