### PR TITLE
Add pyupgrade to linters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ xdist = [
 linting = [
     "editorconfig-checker==3.2.1",
     "mypy==2.3.0",
+    "pyupgrade==3.21.2",
     "ruff==0.16.1",
     "zizmor==1.11.0",
 ]

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -208,7 +208,7 @@ def _django_db_helper(
     request: pytest.FixtureRequest,
     django_db_setup: None,  # noqa: ARG001
     django_db_blocker: DjangoDbBlocker,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     if is_django_unittest(request):
         yield
         return
@@ -575,7 +575,7 @@ class SettingsWrapper:
 
 
 @pytest.fixture
-def settings() -> Generator[SettingsWrapper, None, None]:
+def settings() -> Generator[SettingsWrapper]:
     """A Django settings object which restores changes after the testrun"""
     skip_if_no_django()
 
@@ -587,7 +587,7 @@ def settings() -> Generator[SettingsWrapper, None, None]:
 @pytest.fixture(scope="session")
 def live_server(
     request: pytest.FixtureRequest,
-) -> Generator[live_server_helper.LiveServer, None, None]:
+) -> Generator[live_server_helper.LiveServer]:
     """Run a live Django server in the background during tests
 
     The address the server is started from is taken from the
@@ -620,7 +620,7 @@ def live_server(
 
 
 @pytest.fixture(autouse=True)
-def _live_server_helper(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+def _live_server_helper(request: pytest.FixtureRequest) -> Generator[None]:
     """Helper to make live_server work, internal to pytest-django.
 
     This helper will dynamically request the transactional_db fixture
@@ -671,7 +671,7 @@ def _assert_num_queries(
     info: str | None = None,
     *,
     using: str | None = None,
-) -> Generator[django.test.utils.CaptureQueriesContext, None, None]:
+) -> Generator[django.test.utils.CaptureQueriesContext]:
     from django.db import connection as default_conn, connections
     from django.test.utils import CaptureQueriesContext
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -168,7 +168,7 @@ def django_db_setup(  # noqa: PLR0917
     django_db_keepdb: bool,
     django_db_createdb: bool,
     django_db_modify_db_settings: None,  # noqa: ARG001
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Top level fixture to ensure test databases are available"""
     from django.test.utils import setup_databases, teardown_databases
 

--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -180,7 +180,7 @@ PROJECT_SCAN_DISABLED = (
 
 
 @contextlib.contextmanager
-def _handle_import_error(extra_message: str) -> Generator[None, None, None]:
+def _handle_import_error(extra_message: str) -> Generator[None]:
     # An invalid DJANGO_SETTINGS_MODULE raises ImportError on Django < 6.2, but
     # Django >= 6.2 wraps it in ImproperlyConfigured. Handle both so the
     # guidance message is shown regardless of the Django version.
@@ -506,7 +506,7 @@ def pytest_unconfigure(config: pytest.Config) -> None:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def django_test_environment(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+def django_test_environment(request: pytest.FixtureRequest) -> Generator[None]:
     """Setup Django's test environment for the testing session.
 
     XXX It is a little dodgy that this is an autouse fixture.  Perhaps
@@ -575,7 +575,7 @@ def _django_db_marker(request: pytest.FixtureRequest) -> None:
 def _django_setup_unittest(
     request: pytest.FixtureRequest,
     django_db_blocker: DjangoDbBlocker,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Setup a django unittest, internal to pytest-django."""
     if not django_settings_is_configured() or not is_django_unittest(request):
         yield
@@ -655,7 +655,7 @@ def django_mail_dnsname() -> str:
 
 
 @pytest.fixture(autouse=True)
-def _django_set_urlconf(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+def _django_set_urlconf(request: pytest.FixtureRequest) -> Generator[None]:
     """Apply the @pytest.mark.urls marker, internal to pytest-django."""
     marker: pytest.Mark | None = request.node.get_closest_marker("urls")
     if marker:
@@ -682,7 +682,7 @@ def _django_set_urlconf(request: pytest.FixtureRequest) -> Generator[None, None,
 @pytest.fixture(autouse=True)
 def _django_isolate_apps(
     request: pytest.FixtureRequest,
-) -> Generator[django.apps.registry.Apps, None, None]:
+) -> Generator[django.apps.registry.Apps]:
     """Apply the @pytest.mark.django_isolate_apps marker if present, internal to pytest-django."""
     marker: pytest.Mark | None = request.node.get_closest_marker("django_isolate_apps")
     if not marker:
@@ -713,7 +713,7 @@ def django_isolated_apps(
 
 
 @pytest.fixture(autouse=True, scope="session")
-def _fail_for_invalid_template_variable() -> Generator[None, None, None]:
+def _fail_for_invalid_template_variable() -> Generator[None]:
     """Fixture that fails for invalid variables in templates.
 
     This fixture will fail each test that uses django template rendering

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -198,7 +198,7 @@ class TestDatabaseFixtures:
         assert Item.objects.count() == 0
 
     @pytest.fixture
-    def fin(self, all_dbs: None) -> Generator[None, None, None]:  # noqa: ARG002
+    def fin(self, all_dbs: None) -> Generator[None]:  # noqa: ARG002
         # This finalizer must be able to access the database
         yield
         Item.objects.create(name="spam")

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 
 @contextmanager
-def nonverbose_config(config: pytest.Config) -> Generator[None, None, None]:
+def nonverbose_config(config: pytest.Config) -> Generator[None]:
     """Ensure that pytest's config.option.verbose is <= 0."""
     if config.option.verbose <= 0:
         yield

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ dependency_groups = linting
 commands =
     ruff check {posargs:pytest_django pytest_django_test tests}
     ruff format --quiet --diff {posargs:pytest_django pytest_django_test tests}
+    python scripts/pyupgrade_check.py
     mypy {posargs:pytest_django pytest_django_test tests}
     ec .
     python -c "import subprocess, sys; sys.exit(subprocess.call('zizmor --persona=pedantic --format sarif .github/workflows/deploy.yml .github/workflows/main.yml > zizmor.sarif', shell=True))"

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ dependency_groups = linting
 commands =
     ruff check {posargs:pytest_django pytest_django_test tests}
     ruff format --quiet --diff {posargs:pytest_django pytest_django_test tests}
-    python scripts/pyupgrade_check.py
+    python -c "import subprocess, sys, pathlib; files = [str(p) for d in ('pytest_django', 'pytest_django_test', 'tests') for p in pathlib.Path(d).rglob('*.py')]; sys.exit(subprocess.call(['pyupgrade', '--py310-plus', *files]))"
     mypy {posargs:pytest_django pytest_django_test tests}
     ec .
     python -c "import subprocess, sys; sys.exit(subprocess.call('zizmor --persona=pedantic --format sarif .github/workflows/deploy.yml .github/workflows/main.yml > zizmor.sarif', shell=True))"


### PR DESCRIPTION
- Added `pyupgrade` to the linting dependencies in `pyproject.toml`.
- Updated various function type annotations in `pytest_django` and test files to remove unnecessary `None` return types, enhancing type accuracy and clarity.

These changes aim to improve code quality and maintainability.