### PR TITLE
Add django-upgrade dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ xdist = [
     "pytest-xdist",
 ]
 linting = [
+    "django-upgrade==1.31.1",
     "editorconfig-checker==3.2.1",
     "mypy==2.3.0",
     "ruff==0.16.1",

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ dependency_groups = linting
 commands =
     ruff check {posargs:pytest_django pytest_django_test tests}
     ruff format --quiet --diff {posargs:pytest_django pytest_django_test tests}
+    python -c "import subprocess, sys, pathlib; files = [str(p) for d in ['pytest_django', 'pytest_django_test', 'tests'] for p in pathlib.Path(d).rglob('*.py')]; sys.exit(subprocess.call(['django-upgrade', '--target-version', '5.2', *files]))"
     mypy {posargs:pytest_django pytest_django_test tests}
     ec .
     python -c "import subprocess, sys; sys.exit(subprocess.call('zizmor --persona=pedantic --format sarif .github/workflows/deploy.yml .github/workflows/main.yml > zizmor.sarif', shell=True))"


### PR DESCRIPTION
- Added `django-upgrade==1.31.1` to the linting dependencies in `pyproject.toml`.
- Updated `tox.ini` to include a command for running `django-upgrade` on specified directories.

These changes enhance the linting process by incorporating Django upgrade checks.