### PR TITLE
 asserts: move type annotations to an asserts.pyi stubs file 

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -8,7 +8,8 @@
     "pytest_django.egg-info/*",
     "__pycache__/*",
     "zizmor.sarif",
-    "docs/_build/*"
+    "docs/_build/*",
+    ".venv/"
   ],
   "Disable": {
     "MaxLineLength": true

--- a/pytest_django/asserts.py
+++ b/pytest_django/asserts.py
@@ -1,12 +1,12 @@
 """
 Dynamically load all Django assertion cases and expose them for importing.
 """
-# ruff: noqa: PLR0917
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import Any
 
 from django import VERSION
 from django.test import LiveServerTestCase, SimpleTestCase, TestCase, TransactionTestCase
@@ -15,7 +15,6 @@ from django.test import LiveServerTestCase, SimpleTestCase, TestCase, Transactio
 USE_CONTRIB_MESSAGES = VERSION >= (5, 0)
 
 if USE_CONTRIB_MESSAGES:
-    from django.contrib.messages import Message
     from django.contrib.messages.test import MessagesTestMixin
 
     class MessagesTestCase(MessagesTestMixin, TestCase):
@@ -24,15 +23,6 @@ if USE_CONTRIB_MESSAGES:
     test_case = MessagesTestCase("run")
 else:
     test_case = TestCase("run")
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Sequence
-    from contextlib import AbstractContextManager
-    from typing import Any, overload
-
-    from django import forms
-    from django.db.models import Model, QuerySet, RawQuerySet
-    from django.http.response import HttpResponseBase
 
 
 def _wrapper(name: str) -> Callable[..., Any]:
@@ -62,236 +52,3 @@ if USE_CONTRIB_MESSAGES:
 for assert_func in assertions_names:
     globals()[assert_func] = _wrapper(assert_func)
     __all__.append(assert_func)  # noqa: PYI056
-
-
-if TYPE_CHECKING:
-
-    def assertRedirects(
-        response: HttpResponseBase,
-        expected_url: str,
-        status_code: int = ...,
-        target_status_code: int = ...,
-        msg_prefix: str = ...,
-        fetch_redirect_response: bool = ...,
-    ) -> None: ...
-
-    def assertURLEqual(
-        url1: str,
-        url2: str,
-        msg_prefix: str = ...,
-    ) -> None: ...
-
-    def assertContains(
-        response: HttpResponseBase,
-        text: object,
-        count: int | None = ...,
-        status_code: int = ...,
-        msg_prefix: str = ...,
-        html: bool = False,
-    ) -> None: ...
-
-    def assertNotContains(
-        response: HttpResponseBase,
-        text: object,
-        status_code: int = ...,
-        msg_prefix: str = ...,
-        html: bool = False,
-    ) -> None: ...
-
-    def assertFormError(
-        form: forms.BaseForm,
-        field: str | None,
-        errors: str | Sequence[str],
-        msg_prefix: str = ...,
-    ) -> None: ...
-
-    def assertFormSetError(
-        formset: forms.BaseFormSet,
-        form_index: int | None,
-        field: str | None,
-        errors: str | Sequence[str],
-        msg_prefix: str = ...,
-    ) -> None: ...
-
-    # with assertTemplateUsed("template.html"): ...  # noqa: ERA001
-    @overload
-    def assertTemplateUsed(
-        response: str,
-        template_name: None = ...,
-        msg_prefix: str = ...,
-        count: int | None = ...,
-    ) -> AbstractContextManager[Any]: ...
-
-    # with assertTemplateUsed(template_name="template.html"): ...  # noqa: ERA001
-    @overload
-    def assertTemplateUsed(
-        response: None = ...,
-        template_name: str | None = ...,
-        msg_prefix: str = ...,
-        count: int | None = ...,
-    ) -> AbstractContextManager[Any]: ...
-
-    # assertTemplateUsed(response, "template.html")  # noqa: ERA001
-    @overload
-    def assertTemplateUsed(
-        response: HttpResponseBase,
-        template_name: str | None = ...,
-        msg_prefix: str = ...,
-        count: int | None = ...,
-    ) -> None: ...
-
-    def assertTemplateUsed(
-        response: HttpResponseBase | str | None = ...,
-        template_name: str | None = ...,
-        msg_prefix: str = ...,
-        count: int | None = ...,
-    ): ...
-
-    # with assertTemplateNotUsed("template.html"): ...  # noqa: ERA001
-    @overload
-    def assertTemplateNotUsed(
-        response: str,
-        template_name: None = ...,
-        msg_prefix: str = ...,
-    ) -> AbstractContextManager[Any]: ...
-
-    # with assertTemplateNotUsed(template_name="template.html"): ...  # noqa: ERA001
-    @overload
-    def assertTemplateNotUsed(
-        response: None = ...,
-        template_name: str | None = ...,
-        msg_prefix: str = ...,
-    ) -> AbstractContextManager[Any]: ...
-
-    # assertTemplateNotUsed(response, "template.html")  # noqa: ERA001
-    @overload
-    def assertTemplateNotUsed(
-        response: HttpResponseBase,
-        template_name: str | None = ...,
-        msg_prefix: str = ...,
-    ) -> None: ...
-
-    def assertTemplateNotUsed(
-        response: HttpResponseBase | str | None = ...,
-        template_name: str | None = ...,
-        msg_prefix: str = ...,
-    ): ...
-
-    def assertRaisesMessage(
-        expected_exception: type[Exception],
-        expected_message: str,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any: ...
-
-    def assertWarnsMessage(
-        expected_warning: Warning,
-        expected_message: str,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any: ...
-
-    def assertFieldOutput(
-        fieldclass: type[forms.Field],
-        valid: Any,
-        invalid: Any,
-        field_args: Any = ...,
-        field_kwargs: Any = ...,
-        empty_value: str = ...,
-    ) -> Any: ...
-
-    def assertHTMLEqual(
-        html1: str,
-        html2: str,
-        msg: str | None = ...,
-    ) -> None: ...
-
-    def assertHTMLNotEqual(
-        html1: str,
-        html2: str,
-        msg: str | None = ...,
-    ) -> None: ...
-
-    def assertInHTML(
-        needle: str,
-        haystack: str,
-        count: int | None = ...,
-        msg_prefix: str = ...,
-    ) -> None: ...
-
-    # Added in Django 5.1.
-    def assertNotInHTML(
-        needle: str,
-        haystack: str,
-        msg_prefix: str = ...,
-    ) -> None: ...
-
-    def assertJSONEqual(
-        raw: str,
-        expected_data: Any,
-        msg: str | None = ...,
-    ) -> None: ...
-
-    def assertJSONNotEqual(
-        raw: str,
-        expected_data: Any,
-        msg: str | None = ...,
-    ) -> None: ...
-
-    def assertXMLEqual(
-        xml1: str,
-        xml2: str,
-        msg: str | None = ...,
-    ) -> None: ...
-
-    def assertXMLNotEqual(
-        xml1: str,
-        xml2: str,
-        msg: str | None = ...,
-    ) -> None: ...
-
-    # Removed in Django 5.1: use assertQuerySetEqual.
-    def assertQuerysetEqual(
-        qs: Iterator[Any] | list[Model] | QuerySet | RawQuerySet,
-        values: Iterable[Any],
-        transform: Callable[[Model], Any] | type[str] | None = ...,
-        ordered: bool = ...,
-        msg: str | None = ...,
-    ) -> None: ...
-
-    def assertQuerySetEqual(
-        qs: Iterator[Any] | list[Model] | QuerySet | RawQuerySet,
-        values: Iterable[Any],
-        transform: Callable[[Model], Any] | type[str] | None = ...,
-        ordered: bool = ...,
-        msg: str | None = ...,
-    ) -> None: ...
-
-    @overload
-    def assertNumQueries(
-        num: int, func: None = None, *, using: str = ...
-    ) -> AbstractContextManager[Any]: ...
-
-    @overload
-    def assertNumQueries(
-        num: int, func: Callable[..., Any], *args: Any, using: str = ..., **kwargs: Any
-    ) -> None: ...
-
-    def assertNumQueries(
-        num: int,
-        func=...,
-        *args: Any,
-        using: str = ...,
-        **kwargs: Any,
-    ): ...
-
-    # Added in Django 5.0.
-    def assertMessages(
-        response: HttpResponseBase,
-        expected_messages: Sequence[Message],
-        *args: Any,
-        ordered: bool = ...,
-    ) -> None: ...
-
-    # Fallback in case Django adds new asserts.
-    def __getattr__(name: str) -> Callable[..., Any]: ...

--- a/pytest_django/asserts.pyi
+++ b/pytest_django/asserts.pyi
@@ -1,0 +1,199 @@
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from contextlib import AbstractContextManager
+from typing import Any, overload
+
+from django import forms
+from django.contrib.messages import Message
+from django.db.models import Model, QuerySet, RawQuerySet
+from django.http.response import HttpResponseBase
+
+def assertRedirects(
+    response: HttpResponseBase,
+    expected_url: str,
+    status_code: int = ...,
+    target_status_code: int = ...,
+    msg_prefix: str = ...,
+    fetch_redirect_response: bool = ...,
+) -> None: ...
+def assertURLEqual(
+    url1: str,
+    url2: str,
+    msg_prefix: str = ...,
+) -> None: ...
+def assertContains(
+    response: HttpResponseBase,
+    text: object,
+    count: int | None = ...,
+    status_code: int = ...,
+    msg_prefix: str = ...,
+    html: bool = False,
+) -> None: ...
+def assertNotContains(
+    response: HttpResponseBase,
+    text: object,
+    status_code: int = ...,
+    msg_prefix: str = ...,
+    html: bool = False,
+) -> None: ...
+def assertFormError(
+    form: forms.BaseForm,
+    field: str | None,
+    errors: str | Sequence[str],
+    msg_prefix: str = ...,
+) -> None: ...
+def assertFormSetError(
+    formset: forms.BaseFormSet,
+    form_index: int | None,
+    field: str | None,
+    errors: str | Sequence[str],
+    msg_prefix: str = ...,
+) -> None: ...
+
+# with assertTemplateUsed("template.html"): ...  # noqa: ERA001
+@overload
+def assertTemplateUsed(
+    response: str,
+    template_name: None = ...,
+    msg_prefix: str = ...,
+    count: int | None = ...,
+) -> AbstractContextManager[Any]: ...
+
+# with assertTemplateUsed(template_name="template.html"): ...  # noqa: ERA001
+@overload
+def assertTemplateUsed(
+    response: None = ...,
+    template_name: str | None = ...,
+    msg_prefix: str = ...,
+    count: int | None = ...,
+) -> AbstractContextManager[Any]: ...
+
+# assertTemplateUsed(response, "template.html")  # noqa: ERA001
+@overload
+def assertTemplateUsed(
+    response: HttpResponseBase,
+    template_name: str | None = ...,
+    msg_prefix: str = ...,
+    count: int | None = ...,
+) -> None: ...
+
+# with assertTemplateNotUsed("template.html"): ...  # noqa: ERA001
+@overload
+def assertTemplateNotUsed(
+    response: str,
+    template_name: None = ...,
+    msg_prefix: str = ...,
+) -> AbstractContextManager[Any]: ...
+
+# with assertTemplateNotUsed(template_name="template.html"): ...  # noqa: ERA001
+@overload
+def assertTemplateNotUsed(
+    response: None = ...,
+    template_name: str | None = ...,
+    msg_prefix: str = ...,
+) -> AbstractContextManager[Any]: ...
+
+# assertTemplateNotUsed(response, "template.html")  # noqa: ERA001
+@overload
+def assertTemplateNotUsed(
+    response: HttpResponseBase,
+    template_name: str | None = ...,
+    msg_prefix: str = ...,
+) -> None: ...
+def assertRaisesMessage(
+    expected_exception: type[Exception],
+    expected_message: str,
+    *args: Any,
+    **kwargs: Any,
+) -> Any: ...
+def assertWarnsMessage(
+    expected_warning: Warning,
+    expected_message: str,
+    *args: Any,
+    **kwargs: Any,
+) -> Any: ...
+def assertFieldOutput(
+    fieldclass: type[forms.Field],
+    valid: Any,
+    invalid: Any,
+    field_args: Any = ...,
+    field_kwargs: Any = ...,
+    empty_value: str = ...,
+) -> Any: ...
+def assertHTMLEqual(
+    html1: str,
+    html2: str,
+    msg: str | None = ...,
+) -> None: ...
+def assertHTMLNotEqual(
+    html1: str,
+    html2: str,
+    msg: str | None = ...,
+) -> None: ...
+def assertInHTML(
+    needle: str,
+    haystack: str,
+    count: int | None = ...,
+    msg_prefix: str = ...,
+) -> None: ...
+
+# Added in Django 5.1.
+def assertNotInHTML(
+    needle: str,
+    haystack: str,
+    msg_prefix: str = ...,
+) -> None: ...
+def assertJSONEqual(
+    raw: str,
+    expected_data: Any,
+    msg: str | None = ...,
+) -> None: ...
+def assertJSONNotEqual(
+    raw: str,
+    expected_data: Any,
+    msg: str | None = ...,
+) -> None: ...
+def assertXMLEqual(
+    xml1: str,
+    xml2: str,
+    msg: str | None = ...,
+) -> None: ...
+def assertXMLNotEqual(
+    xml1: str,
+    xml2: str,
+    msg: str | None = ...,
+) -> None: ...
+
+# Removed in Django 5.1: use assertQuerySetEqual.
+def assertQuerysetEqual(
+    qs: Iterator[Any] | list[Model] | QuerySet | RawQuerySet,
+    values: Iterable[Any],
+    transform: Callable[[Model], Any] | type[str] | None = ...,
+    ordered: bool = ...,
+    msg: str | None = ...,
+) -> None: ...
+def assertQuerySetEqual(
+    qs: Iterator[Any] | list[Model] | QuerySet | RawQuerySet,
+    values: Iterable[Any],
+    transform: Callable[[Model], Any] | type[str] | None = ...,
+    ordered: bool = ...,
+    msg: str | None = ...,
+) -> None: ...
+@overload
+def assertNumQueries(
+    num: int, func: None = None, *, using: str = ...
+) -> AbstractContextManager[Any]: ...
+@overload
+def assertNumQueries(
+    num: int, func: Callable[..., Any], *args: Any, using: str = ..., **kwargs: Any
+) -> None: ...
+
+# Added in Django 5.0.
+def assertMessages(
+    response: HttpResponseBase,
+    expected_messages: Sequence[Message],
+    *args: Any,
+    ordered: bool = ...,
+) -> None: ...
+
+# Fallback in case Django adds new asserts.
+def __getattr__(name: str) -> Callable[..., Any]: ...

--- a/tests/test_asserts.py
+++ b/tests/test_asserts.py
@@ -5,6 +5,8 @@ Tests the dynamic loading of all Django assertion cases.
 from __future__ import annotations
 
 import inspect
+from collections.abc import Sequence
+from typing import cast
 
 import pytest
 
@@ -47,7 +49,7 @@ def _get_actual_assertions_names() -> list[str]:
 
 def test_django_asserts_available() -> None:
     django_assertions = _get_actual_assertions_names()
-    expected_assertions = asserts_all
+    expected_assertions = cast(Sequence[str], asserts_all)
     assert set(django_assertions) == set(expected_assertions)
 
     for name in expected_assertions:


### PR DESCRIPTION
Let's clearly separate the typing and implementation, instead of using a
large `TYPE_CHECKING` block. Stubs also have more flexible rules, like
not needed an implementation function signature for overloads.