### PR TITLE
Fix `_pre_setup_ran_eagerly` on Django 5.0 and 5.1

### DIFF
--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -213,6 +213,8 @@ def _django_db_helper(
         yield
         return
 
+    from django import VERSION
+
     marker = request.node.get_closest_marker("django_db")
     if marker:
         (
@@ -289,7 +291,11 @@ def _django_db_helper(
         PytestDjangoTestCase.setUpClass()
 
         test_case = PytestDjangoTestCase(methodName="__init__")
-        if not PytestDjangoTestCase._pre_setup_ran_eagerly:
+        if VERSION >= (6, 0):
+            pre_setup_ran_eagerly = PytestDjangoTestCase._pre_setup_ran_eagerly
+        else:
+            pre_setup_ran_eagerly = getattr(PytestDjangoTestCase, "_pre_setup_ran_eagerly", False)
+        if not pre_setup_ran_eagerly:
             # For a TransactionTestCase, setUpClass() has already run _pre_setup() and set
             # this flag to say so.
             test_case._pre_setup()

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -289,7 +289,7 @@ def _django_db_helper(
         PytestDjangoTestCase.setUpClass()
 
         test_case = PytestDjangoTestCase(methodName="__init__")
-        if not PytestDjangoTestCase._pre_setup_ran_eagerly:
+        if not getattr(PytestDjangoTestCase, "_pre_setup_ran_eagerly", False):
             # For a TransactionTestCase, setUpClass() has already run _pre_setup() and set
             # this flag to say so.
             test_case._pre_setup()


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest-django/issues/1303

Locally I double checked that:
- It now works with 5.0 and 5.1
- `False` is the correct default, with `True` I get errors like

```
ERROR tests/test_unit/test_security/test_token/test_app/test_token_model.py::test_create_token_explicit_expiry - AttributeError: 'PytestDjangoTestCase' object has no attribute 'atomics'
ERROR tests/test_unit/test_security/test_token/test_app/test_token_model.py::test_token_is_expired - AttributeError: 'PytestDjangoTestCase' object has no attribute 'atomics'
ERROR tests/test_unit/test_security/test_token/test_app/test_token_model.py::test_token_revoke - AttributeError: 'PytestDjangoTestCase' object has no attribute 'atomics'
ERROR tests/test_unit/test_security/test_token/test_app/test_token_model.py::test_hash_token_is_stored - AttributeError: 'PytestDjangoTestCase' object has no attribute 'atomics'
ERROR tests/test_unit/test_security/test_token/test_app/test_token_model.py::test_create_token_without_expiry - AttributeError: 'PytestDjangoTestCase' object has no attribute 'atomics'
ERROR tests/test_unit/test_security/test_token/test_app/test_token_model.py::test_create_token - AttributeError: 'PytestDjangoTestCase' object has no attribute 'atomics'
```