### PR TITLE
Support database transactions in async tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Next
+----
+
+Bugfixes
+^^^^^^^^
+
+* Fixed database transaction isolation for asyncio tests using Django's async
+  ORM (`#580 <https://github.com/pytest-dev/pytest-django/issues/580>`__).
+
 v4.13.0 (2026-08-06)
 --------------------
 

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -60,6 +60,30 @@ select using an argument to the ``django_db`` mark::
    def test_spam():
        pass  # test relying on transactions
 
+
+Async tests
+-----------
+
+Database access also works in async tests managed by
+`pytest-asyncio <https://pytest-asyncio.readthedocs.io/>`_. Mark the test for
+both asyncio and database access, then use Django's async ORM methods::
+
+   @pytest.mark.asyncio
+   @pytest.mark.django_db
+   async def test_async_user():
+       user = await User.objects.acreate(username="me")
+       assert user.username == "me"
+
+The :fixture:`db` fixture still wraps the test in a transaction and rolls it
+back afterward. Django runs async ORM operations on a dedicated synchronous
+executor thread. For an asyncio test, ``pytest-django`` shares the database
+connection between the main thread, where fixtures and transaction setup run,
+and that executor thread. This means synchronous fixtures and async test code
+participate in the same transaction.
+
+Sharing is limited to these two threads and lasts only for the test. Django's
+usual thread-sharing validation continues to apply to any other threads.
+
 .. _`multi-db`:
 
 Tests requiring multiple databases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ testing = [
     "Django",
     "django-configurations>=2.0",
     "pytest>=9",
+    "pytest-asyncio",
 ]
 coverage = [
     "coverage[toml]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ files = [
 ]
 [[tool.mypy.overrides]]
 module = [
+    "asgiref.*",
     "django.*",
     "configurations.*",
 ]

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import os
+import threading
+import types
 from collections.abc import Callable, Generator, Iterable, Sequence
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
 from functools import partial
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -203,6 +205,128 @@ def django_db_setup(  # noqa: PLR0917
                 )
 
 
+@contextmanager
+def _override_instance_attribute(instance: Any, name: str, value: Any) -> Generator[None]:
+    """Temporarily replace an instance attribute and restore its exact previous state.
+
+    ``object.__setattr__`` deliberately bypasses custom ``__setattr__``
+    implementations such as the one used by ``asgiref.local.Local``. The
+    sentinel distinguishes an absent instance attribute from one whose value
+    was ``None``, so an inherited method is exposed again by deleting the
+    override rather than leaving a bound copy on the instance.
+    """
+    sentinel = object()
+    previous_value = vars(instance).get(name, sentinel)
+    object.__setattr__(instance, name, value)
+    try:
+        yield
+    finally:
+        if previous_value is sentinel:
+            object.__delattr__(instance, name)
+        else:
+            object.__setattr__(instance, name, previous_value)
+
+
+@contextmanager
+def _share_database_connections_with_async_executor() -> Generator[None]:
+    """Share Django's thread-local connections with the async ORM executor.
+
+    Django stores its database wrappers as attributes on an
+    ``asgiref.local.Local`` instance. With its ``thread_critical`` mode, the
+    main test thread and the thread-sensitive ``SyncToAsync`` executor would
+    normally resolve an alias such as ``default`` to different wrappers. A
+    transaction opened by the synchronous pytest fixture would consequently
+    not contain async ORM queries executed on the executor thread.
+
+    For the lifetime of this context, ``Local._lock_storage`` returns one
+    shared ``SimpleNamespace`` for those two threads. Other threads continue
+    to use the original local storage.
+
+    Existing wrappers are copied into the shared namespace. Wrappers created
+    lazily during the test are handled by a temporary ``create_connection``
+    method. Every shared wrapper also gets a temporary thread-validation
+    method that permits the two participating threads and retains Django's
+    normal validation for all other threads.
+
+    ``ExitStack`` owns all of these temporary method replacements and sets
+    them back to their original values if the test ends or raises an
+    exception. It also allows wrapper overrides to be added after the context
+    has started, as wrappers are discovered or created dynamically.
+    """
+    from asgiref.sync import SyncToAsync
+    from django.db import connections
+
+    main_thread_id = threading.get_ident()
+    executor_thread_id = SyncToAsync.single_thread_executor.submit(threading.get_ident).result()
+    allowed_thread_ids = frozenset({main_thread_id, executor_thread_id})
+
+    connection_local = connections._connections
+    shared_storage = types.SimpleNamespace()
+    original_lock_storage = connection_local._lock_storage
+    original_create_connection = connections.create_connection
+    patched_wrappers: list[Any] = []
+
+    # New wrapper overrides can be added to the stack while the test is
+    # running; all registered overrides are restored when this block exits.
+    with ExitStack() as stack:
+
+        def patch_wrapper(wrapper: Any) -> Any:
+            if any(existing_wrapper is wrapper for existing_wrapper in patched_wrappers):
+                return wrapper
+
+            original_validate_thread_sharing = wrapper.validate_thread_sharing
+
+            def validate_thread_sharing(_wrapper: Any) -> None:
+                if threading.get_ident() in allowed_thread_ids:
+                    return
+                original_validate_thread_sharing()
+
+            stack.enter_context(
+                _override_instance_attribute(
+                    wrapper,
+                    "validate_thread_sharing",
+                    # Functions assigned to an instance do not bind ``self``
+                    # automatically, so explicitly bind this replacement.
+                    types.MethodType(validate_thread_sharing, wrapper),
+                )
+            )
+            patched_wrappers.append(wrapper)
+            return wrapper
+
+        @contextmanager
+        def lock_storage() -> Generator[Any]:
+            if threading.get_ident() in allowed_thread_ids:
+                yield shared_storage
+            else:
+                with original_lock_storage() as storage:
+                    yield storage
+
+        def create_connection(_connections: Any, alias: str) -> Any:
+            # Apply the same validation override to aliases first used after
+            # this context was entered.
+            return patch_wrapper(original_create_connection(alias))
+
+        with original_lock_storage() as storage:
+            for alias in connections:
+                if hasattr(storage, alias):
+                    setattr(shared_storage, alias, patch_wrapper(getattr(storage, alias)))
+
+        # Local.__setattr__ stores non-internal attributes in the local storage,
+        # so override the method on this Local instance itself.
+        stack.enter_context(
+            _override_instance_attribute(connection_local, "_lock_storage", lock_storage)
+        )
+        stack.enter_context(
+            _override_instance_attribute(
+                connections,
+                "create_connection",
+                types.MethodType(create_connection, connections),
+            )
+        )
+
+        yield
+
+
 @pytest.fixture
 def _django_db_helper(
     request: pytest.FixtureRequest,
@@ -241,7 +365,13 @@ def _django_db_helper(
         "django_db_serialized_rollback" in request.fixturenames
     )
 
-    with django_db_blocker.unblock():
+    connection_sharing = (
+        _share_database_connections_with_async_executor()
+        if request.node.get_closest_marker("asyncio")
+        else nullcontext()
+    )
+
+    with django_db_blocker.unblock(), connection_sharing:
         import django.db
         import django.test
 

--- a/pytest_django/fixtures.py
+++ b/pytest_django/fixtures.py
@@ -264,16 +264,12 @@ def _share_database_connections_with_async_executor() -> Generator[None]:
     shared_storage = types.SimpleNamespace()
     original_lock_storage = connection_local._lock_storage
     original_create_connection = connections.create_connection
-    patched_wrappers: list[Any] = []
 
     # New wrapper overrides can be added to the stack while the test is
     # running; all registered overrides are restored when this block exits.
     with ExitStack() as stack:
 
         def patch_wrapper(wrapper: Any) -> Any:
-            if any(existing_wrapper is wrapper for existing_wrapper in patched_wrappers):
-                return wrapper
-
             original_validate_thread_sharing = wrapper.validate_thread_sharing
 
             def validate_thread_sharing(_wrapper: Any) -> None:
@@ -290,7 +286,6 @@ def _share_database_connections_with_async_executor() -> Generator[None]:
                     types.MethodType(validate_thread_sharing, wrapper),
                 )
             )
-            patched_wrappers.append(wrapper)
             return wrapper
 
         @contextmanager

--- a/tests/test_async_database.py
+++ b/tests/test_async_database.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+from django.test import AsyncClient
+
+from pytest_django_test.app.models import Item, SecondItem
+
+
+@pytest.mark.parametrize("run_number", [1, 2])
+@pytest.mark.asyncio
+async def test_async_db_rolls_back_between_tests(db: None, run_number: int) -> None:
+    del db
+
+    assert await Item.objects.acount() == 0
+    await Item.objects.acreate(name=f"async-{run_number}")
+    assert await Item.objects.acount() == 1
+
+
+@pytest.fixture
+def sync_db_item(db: None) -> Item:
+    del db
+    item: Item = Item.objects.create(name="sync fixture")
+    return item
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_async_db_shares_connection_with_sync_fixture(sync_db_item: Item) -> None:
+    item = await Item.objects.aget(pk=sync_db_item.pk)
+
+    assert item.name == sync_db_item.name
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_async_db_connection_is_shared_with_async_client(
+    async_client: AsyncClient,
+    sync_db_item: Item,
+) -> None:
+    response = await async_client.get("/item_count/")
+
+    assert sync_db_item.name == "sync fixture"
+    assert response.content == b"Item count: 1"
+
+
+@pytest.mark.parametrize("run_number", [1, 2])
+@pytest.mark.asyncio
+async def test_async_transactional_db_flushes_between_tests(
+    transactional_db: None,
+    run_number: int,
+) -> None:
+    del transactional_db
+
+    assert await Item.objects.acount() == 0
+    await Item.objects.acreate(name=f"transactional-{run_number}")
+    assert await Item.objects.acount() == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(databases=["default", "second"])
+async def test_async_db_shares_all_selected_database_connections() -> None:
+    await Item.objects.acreate(name="default")
+    await SecondItem.objects.acreate(name="second")
+
+    assert await Item.objects.acount() == 1
+    assert await SecondItem.objects.acount() == 1

--- a/tests/test_async_database.py
+++ b/tests/test_async_database.py
@@ -1,9 +1,28 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
 import pytest
+from django.db import DatabaseError, connections
 from django.test import AsyncClient
 
+from pytest_django.fixtures import _override_instance_attribute
 from pytest_django_test.app.models import Item, SecondItem
+
+
+def test_override_instance_attribute_restores_existing_value() -> None:
+    instance = SimpleNamespace(value="original")
+
+    def replace_then_raise() -> None:
+        with _override_instance_attribute(instance, "value", "replacement"):
+            assert instance.value == "replacement"
+            raise RuntimeError("test exception")
+
+    with pytest.raises(RuntimeError, match="test exception"):
+        replace_then_raise()
+
+    assert instance.value == "original"
 
 
 @pytest.mark.parametrize("run_number", [1, 2])
@@ -41,6 +60,23 @@ async def test_async_db_connection_is_shared_with_async_client(
 
     assert sync_db_item.name == "sync fixture"
     assert response.content == b"Item count: 1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_async_db_keeps_other_threads_isolated() -> None:
+    main_connection = connections["default"]
+
+    def inspect_other_thread() -> object:
+        other_connection = connections["default"]
+        with pytest.raises(DatabaseError):
+            main_connection.validate_thread_sharing()
+        return other_connection
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        other_connection = executor.submit(inspect_other_thread).result()
+
+    assert other_connection is not main_connection
 
 
 @pytest.mark.parametrize("run_number", [1, 2])


### PR DESCRIPTION
Fixes #580.

Supersedes #1223.

# What

Share Django database connections between pytest's main thread and asgiref's thread-sensitive executor for pytest-asyncio tests.

This keeps direct async ORM calls, synchronous fixtures, and Django `AsyncClient` requests inside the transaction managed by pytest-django's `db` fixture.

# Why

pytest-django opens the test transaction on the main thread, while Django executes async ORM work on a synchronous executor thread. Because Django connections are normally thread-local, that work can use a different connection and escape the transaction rollback.

# Deviations

Unlike #1223, database setup and teardown remain synchronous on the main thread. Synchronous fixtures are also left on the main thread rather than moved onto the executor. The connection itself is temporarily shared between both threads.

Support is intentionally scoped to pytest-asyncio's default thread-sensitive executor, as used by direct async ORM calls and Django's test `AsyncClient`. Arbitrary user-created `ThreadSensitiveContext` executors and production ASGI execution are outside this PR's scope.
