### PR TITLE
Add `django` extra to ensure Django dependency compatible lower bound

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,16 @@ Make sure ``DJANGO_SETTINGS_MODULE`` is defined (see
 :ref:`configuring_django_settings`) and make your tests discoverable
 (see :ref:`faq-tests-not-being-picked-up`):
 
+By default, pytest-django does not depend on Django. If you want to ensure your
+Django version is compatible with the installed pytest-django version (lower
+bound only), it's recommended to add the ``django`` `extra`_::
+
+.. code-block:: bash
+
+   $ pip install pytest-django[django]
+
+.. _extra: https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-extras
+
 Example using pytest.ini or tox.ini
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,14 @@ dependencies = [
     "pytest>=7.0.0",
 ]
 [project.optional-dependencies]
+# pytest-django intentionally does not depend on Django. The django extra
+# adds the dependency. The idea is that users can specify it to obtain the
+# lower-bound constraint on pytest-django's supported Django versions. This
+# way if they use an older version of Django, the dependency resolver will
+# give them an older, compatible version of pytest-django.
+django = [
+    "django>=5.2",
+]
 # .readthedocs.yml doesn't support dependency groups yet, so duplicate the docs
 # group as an extra. Can be removed once RTD supports groups.
 docs = [


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest-django/issues/1303#issuecomment-5203867161