### PR TITLE
Fix `mailoutbox` fixture initialization with database-dependent fixtures

### DIFF
--- a/pytest_django/plugin.py
+++ b/pytest_django/plugin.py
@@ -646,11 +646,17 @@ def _dj_autoclear_mailbox() -> None:
 
 @pytest.fixture
 def mailoutbox(
+    request: pytest.FixtureRequest,
     django_mail_patch_dns: None,  # noqa: ARG001
     _dj_autoclear_mailbox: None,
 ) -> list[django.core.mail.EmailMessage] | None:
     """A clean email outbox to which Django-generated emails are sent."""
     skip_if_no_django()
+
+    # Django's TestCase._pre_setup() replaces mail.outbox. Run the database
+    # helper first so mailoutbox returns the replacement list.
+    if "_django_db_helper" in request.fixturenames:
+        request.getfixturevalue("_django_db_helper")
 
     from django.core import mail
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -804,6 +804,23 @@ def test_mail_again(mailoutbox) -> None:
     test_mail(mailoutbox)
 
 
+def test_mailoutbox_with_db(mailoutbox, db: None) -> None:  # noqa: ARG001
+    assert mailoutbox is mail.outbox
+
+
+@pytest.fixture
+def mail_sending_db_fixture(db: None) -> None:  # noqa: ARG001
+    mail.send_mail("subject", "body", "from@example.com", ["to@example.com"])
+
+
+def test_mailoutbox_with_db_dependent_fixture(
+    mailoutbox,
+    mail_sending_db_fixture: None,  # noqa: ARG001
+) -> None:
+    assert mailoutbox is mail.outbox
+    assert len(mailoutbox) == 1
+
+
 def test_mail_message_uses_mocked_DNS_NAME(mailoutbox) -> None:
     mail.send_mail("subject", "body", "from@example.com", ["to@example.com"])
     m = mailoutbox[0]


### PR DESCRIPTION
Fixes #589

Ensure database setup completes before `mailoutbox` captures Django's `mail.outbox` to prevent `mailoutbox` from retaining a stale list when Django's `TestCase._pre_setup()` (that is invoked in `_django_db_helper` fixture) replaces `mail.outbox`.

---

This PR intentionally covers only database dependencies that are visible in pytest's fixture graph. It does not cover fixtures that dynamically request database access after `mailoutbox` has been initialized, for example:

```python
@pytest.fixture
def dynamically_requests_db(request):
    request.getfixturevalue("db")
```

Supporting that case would require a more invasive approach, such as preserving and synchronizing the existing outbox around `_django_db_helper` and Django's `_pre_setup()`. I am happy to change to the broader approach if maintainers prefer it.